### PR TITLE
Moving test classes to testing module

### DIFF
--- a/scoping/build.gradle
+++ b/scoping/build.gradle
@@ -18,6 +18,8 @@ dependencies {
     androidTestImplementation deps.androidx_test_rules
     androidTestImplementation deps.espresso_core
     androidTestImplementation deps.truth
+    androidTestImplementation project(':testing')
+
 }
 
 apply plugin: 'kotlin-android-extensions'

--- a/scoping/src/androidTest/java/com/dropbox/kaiken/scoping/AuthAwareActivitiesTest.kt
+++ b/scoping/src/androidTest/java/com/dropbox/kaiken/scoping/AuthAwareActivitiesTest.kt
@@ -5,7 +5,7 @@ import androidx.test.core.app.ActivityScenario
 import com.google.common.truth.Truth.assertThat
 import org.junit.After
 import org.junit.Test
-import test.com.dropbox.kaiken.scoping.TestAuthAwareScopedActivity
+import test.com.dropbox.kaiken.testing.TestAuthAwareScopedActivity
 
 class AuthAwareActivitiesTest {
     private lateinit var scenario: ActivityScenario<out TestAuthAwareScopedActivity>

--- a/scoping/src/androidTest/java/com/dropbox/kaiken/scoping/AuthAwareBroadcastReceiverTest.kt
+++ b/scoping/src/androidTest/java/com/dropbox/kaiken/scoping/AuthAwareBroadcastReceiverTest.kt
@@ -6,10 +6,10 @@ import android.content.Intent
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
-import test.com.dropbox.kaiken.scoping.MyDependencies
-import test.com.dropbox.kaiken.scoping.TestApplicationContext
-import test.com.dropbox.kaiken.scoping.TestAuthOptionalBroadcastReceiver
-import test.com.dropbox.kaiken.scoping.TestAuthRequiredBroadcastReceiver
+import test.com.dropbox.kaiken.testing.MyDependencies
+import test.com.dropbox.kaiken.testing.TestAuthOptionalBroadcastReceiver
+import test.com.dropbox.kaiken.testing.TestAuthRequiredBroadcastReceiver
+import test.com.dropbox.kaiken.testing.TestApplicationContext
 
 class AuthAwareBroadcastReceiverTest {
     @Test

--- a/scoping/src/androidTest/java/com/dropbox/kaiken/scoping/AuthAwareBroadcastReceiverTest.kt
+++ b/scoping/src/androidTest/java/com/dropbox/kaiken/scoping/AuthAwareBroadcastReceiverTest.kt
@@ -7,9 +7,9 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import test.com.dropbox.kaiken.testing.MyDependencies
+import test.com.dropbox.kaiken.testing.TestApplicationContext
 import test.com.dropbox.kaiken.testing.TestAuthOptionalBroadcastReceiver
 import test.com.dropbox.kaiken.testing.TestAuthRequiredBroadcastReceiver
-import test.com.dropbox.kaiken.testing.TestApplicationContext
 
 class AuthAwareBroadcastReceiverTest {
     @Test

--- a/scoping/src/androidTest/java/com/dropbox/kaiken/scoping/AuthAwareFragmentTest.kt
+++ b/scoping/src/androidTest/java/com/dropbox/kaiken/scoping/AuthAwareFragmentTest.kt
@@ -5,8 +5,8 @@ import androidx.test.core.app.ActivityScenario
 import com.google.common.truth.Truth.assertThat
 import org.junit.After
 import org.junit.Test
-import test.com.dropbox.kaiken.scoping.TestAuthAwareFragment
-import test.com.dropbox.kaiken.scoping.TestAuthAwareScopedActivity
+import test.com.dropbox.kaiken.testing.TestAuthAwareFragment
+import test.com.dropbox.kaiken.testing.TestAuthAwareScopedActivity
 
 class AuthAwareFragmentTest {
     lateinit var scenario: ActivityScenario<out TestAuthAwareScopedActivity>

--- a/scoping/src/androidTest/java/com/dropbox/kaiken/scoping/AuthScopeOwnersFragmentsTest.kt
+++ b/scoping/src/androidTest/java/com/dropbox/kaiken/scoping/AuthScopeOwnersFragmentsTest.kt
@@ -7,9 +7,9 @@ import androidx.test.core.app.ActivityScenario
 import com.google.common.truth.Truth.assertThat
 import org.junit.After
 import org.junit.Test
-import test.com.dropbox.kaiken.scoping.TestAuthAwareFragment
-import test.com.dropbox.kaiken.scoping.TestAuthAwareScopedFragment
-import test.com.dropbox.kaiken.scoping.TestSimpleActivity
+import test.com.dropbox.kaiken.testing.TestAuthAwareFragment
+import test.com.dropbox.kaiken.testing.TestAuthAwareScopedFragment
+import test.com.dropbox.kaiken.testing.TestSimpleActivity
 import kotlin.test.Ignore
 
 class AuthScopeOwnersFragmentsTest {

--- a/scoping/src/androidTest/java/com/dropbox/kaiken/scoping/LaunchActivitiesTestUtils.kt
+++ b/scoping/src/androidTest/java/com/dropbox/kaiken/scoping/LaunchActivitiesTestUtils.kt
@@ -4,9 +4,9 @@ import android.content.Intent
 import androidx.test.core.app.ActivityScenario
 import androidx.test.platform.app.InstrumentationRegistry
 import test.com.dropbox.kaiken.testing.TestAuthAwareScopedActivity
+import test.com.dropbox.kaiken.testing.TestAuthOptionalActivity
 import test.com.dropbox.kaiken.testing.TestAuthRequiredActivity
 import test.com.dropbox.kaiken.testing.TestSimpleActivity
-import test.com.dropbox.kaiken.testing.TestAuthOptionalActivity
 
 internal fun launchAuthRequiredActivity(
     callFinishIfInvalidAuth: Boolean = true,

--- a/scoping/src/androidTest/java/com/dropbox/kaiken/scoping/LaunchActivitiesTestUtils.kt
+++ b/scoping/src/androidTest/java/com/dropbox/kaiken/scoping/LaunchActivitiesTestUtils.kt
@@ -3,10 +3,10 @@ package com.dropbox.kaiken.scoping
 import android.content.Intent
 import androidx.test.core.app.ActivityScenario
 import androidx.test.platform.app.InstrumentationRegistry
-import test.com.dropbox.kaiken.scoping.TestAuthAwareScopedActivity
-import test.com.dropbox.kaiken.scoping.TestAuthOptionalActivity
-import test.com.dropbox.kaiken.scoping.TestAuthRequiredActivity
-import test.com.dropbox.kaiken.scoping.TestSimpleActivity
+import test.com.dropbox.kaiken.testing.TestAuthAwareScopedActivity
+import test.com.dropbox.kaiken.testing.TestAuthRequiredActivity
+import test.com.dropbox.kaiken.testing.TestSimpleActivity
+import test.com.dropbox.kaiken.testing.TestAuthOptionalActivity
 
 internal fun launchAuthRequiredActivity(
     callFinishIfInvalidAuth: Boolean = true,

--- a/scoping/src/androidTest/java/com/dropbox/kaiken/scoping/LaunchFragmentsTestUtils.kt
+++ b/scoping/src/androidTest/java/com/dropbox/kaiken/scoping/LaunchFragmentsTestUtils.kt
@@ -3,11 +3,11 @@ package com.dropbox.kaiken.scoping
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import androidx.test.core.app.ActivityScenario
-import test.com.dropbox.kaiken.scoping.TestActivity
-import test.com.dropbox.kaiken.scoping.TestAuthAwareFragment
-import test.com.dropbox.kaiken.scoping.TestAuthAwareScopedFragment
-import test.com.dropbox.kaiken.scoping.TestAuthOptionalFragment
-import test.com.dropbox.kaiken.scoping.TestAuthRequiredFragment
+import test.com.dropbox.kaiken.testing.TestActivity
+import test.com.dropbox.kaiken.testing.TestAuthAwareFragment
+import test.com.dropbox.kaiken.testing.TestAuthAwareScopedFragment
+import test.com.dropbox.kaiken.testing.TestAuthOptionalFragment
+import test.com.dropbox.kaiken.testing.TestAuthRequiredFragment
 
 internal const val FRAGMENT_TAG = "AUTH_AWARE_FRAGMENT"
 internal const val CHILD_FRAGMENT_TAG = "CHILD_AUTH_AWARE_FRAGMENT"

--- a/scoping/src/debug/java/test/com/dropbox/kaiken/scoping/TestAuthRequireBroadcastReceived.kt
+++ b/scoping/src/debug/java/test/com/dropbox/kaiken/scoping/TestAuthRequireBroadcastReceived.kt
@@ -1,1 +1,0 @@
-package test.com.dropbox.kaiken.scoping

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -4,6 +4,9 @@ apply plugin: 'com.vanniktech.maven.publish'
 
 dependencies {
     implementation project(':runtime')
+    implementation project(':scoping')
+    implementation deps.androidx_fragment
     implementation deps.androidx_test_rules
+    implementation deps.appcompat
     implementation deps.kotlinStdLib
 }

--- a/testing/src/debug/AndroidManifest.xml
+++ b/testing/src/debug/AndroidManifest.xml
@@ -3,15 +3,15 @@
   -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application>
-        <activity android:name="test.com.dropbox.kaiken.scoping.TestAuthRequiredActivity"
+        <activity android:name="test.com.dropbox.kaiken.testing.TestAuthRequiredActivity"
             android:theme="@style/Theme.AppCompat.DayNight.NoActionBar"
             android:exported="false">
         </activity>
-        <activity android:name="test.com.dropbox.kaiken.scoping.TestAuthOptionalActivity"
+        <activity android:name="test.com.dropbox.kaiken.testing.TestAuthOptionalActivity"
             android:theme="@style/Theme.AppCompat.DayNight.NoActionBar"
             android:exported="false">
         </activity>
-        <activity android:name="test.com.dropbox.kaiken.scoping.TestSimpleActivity"
+        <activity android:name="test.com.dropbox.kaiken.testing.TestSimpleActivity"
             android:theme="@style/Theme.AppCompat.DayNight.NoActionBar"
             android:exported="false">
         </activity>

--- a/testing/src/debug/java/test/com/dropbox/kaiken/testing/MyDependencies.kt
+++ b/testing/src/debug/java/test/com/dropbox/kaiken/testing/MyDependencies.kt
@@ -1,4 +1,4 @@
-package test.com.dropbox.kaiken.scoping
+package test.com.dropbox.kaiken.testing
 
 interface MyDependencies {
     fun helloWorldGreeter(): HelloWorldGreeter

--- a/testing/src/debug/java/test/com/dropbox/kaiken/testing/TestActivity.kt
+++ b/testing/src/debug/java/test/com/dropbox/kaiken/testing/TestActivity.kt
@@ -1,4 +1,4 @@
-package test.com.dropbox.kaiken.scoping
+package test.com.dropbox.kaiken.testing
 
 import android.content.Context
 import android.content.ContextWrapper

--- a/testing/src/debug/java/test/com/dropbox/kaiken/testing/TestAuthAwareBroadcastReceiver.kt
+++ b/testing/src/debug/java/test/com/dropbox/kaiken/testing/TestAuthAwareBroadcastReceiver.kt
@@ -1,4 +1,4 @@
-package test.com.dropbox.kaiken.scoping
+package test.com.dropbox.kaiken.testing
 
 import android.content.BroadcastReceiver
 import android.content.Context

--- a/testing/src/debug/java/test/com/dropbox/kaiken/testing/TestAuthAwareFragment.kt
+++ b/testing/src/debug/java/test/com/dropbox/kaiken/testing/TestAuthAwareFragment.kt
@@ -1,4 +1,4 @@
-package test.com.dropbox.kaiken.scoping
+package test.com.dropbox.kaiken.testing
 
 import android.content.Context
 import androidx.fragment.app.Fragment

--- a/testing/src/debug/java/test/com/dropbox/kaiken/testing/TestAuthAwareScopedActivity.kt
+++ b/testing/src/debug/java/test/com/dropbox/kaiken/testing/TestAuthAwareScopedActivity.kt
@@ -1,4 +1,4 @@
-package test.com.dropbox.kaiken.scoping
+package test.com.dropbox.kaiken.testing
 
 import android.os.Bundle
 import com.dropbox.kaiken.scoping.AuthAwareScopeOwnerActivity

--- a/testing/src/debug/java/test/com/dropbox/kaiken/testing/TestAuthAwareScopedFragment.kt
+++ b/testing/src/debug/java/test/com/dropbox/kaiken/testing/TestAuthAwareScopedFragment.kt
@@ -1,4 +1,4 @@
-package test.com.dropbox.kaiken.scoping
+package test.com.dropbox.kaiken.testing
 
 import android.content.Context
 import androidx.fragment.app.Fragment

--- a/testing/src/debug/java/test/com/dropbox/kaiken/testing/TestAuthOptionalActivity.kt
+++ b/testing/src/debug/java/test/com/dropbox/kaiken/testing/TestAuthOptionalActivity.kt
@@ -1,4 +1,4 @@
-package test.com.dropbox.kaiken.scoping
+package test.com.dropbox.kaiken.testing
 
 import com.dropbox.kaiken.scoping.AuthOptionalActivity
 

--- a/testing/src/debug/java/test/com/dropbox/kaiken/testing/TestAuthOptionalBroadcastReceiver.kt
+++ b/testing/src/debug/java/test/com/dropbox/kaiken/testing/TestAuthOptionalBroadcastReceiver.kt
@@ -1,4 +1,4 @@
-package test.com.dropbox.kaiken.scoping
+package test.com.dropbox.kaiken.testing
 
 import com.dropbox.kaiken.scoping.AuthOptionalBroadcastReceiver
 

--- a/testing/src/debug/java/test/com/dropbox/kaiken/testing/TestAuthOptionalFragment.kt
+++ b/testing/src/debug/java/test/com/dropbox/kaiken/testing/TestAuthOptionalFragment.kt
@@ -1,4 +1,4 @@
-package test.com.dropbox.kaiken.scoping
+package test.com.dropbox.kaiken.testing
 
 import com.dropbox.kaiken.scoping.AuthOptionalFragment
 

--- a/testing/src/debug/java/test/com/dropbox/kaiken/testing/TestAuthRequireBroadcastReceived.kt
+++ b/testing/src/debug/java/test/com/dropbox/kaiken/testing/TestAuthRequireBroadcastReceived.kt
@@ -1,0 +1,1 @@
+package test.com.dropbox.kaiken.testing

--- a/testing/src/debug/java/test/com/dropbox/kaiken/testing/TestAuthRequiredActivity.kt
+++ b/testing/src/debug/java/test/com/dropbox/kaiken/testing/TestAuthRequiredActivity.kt
@@ -1,4 +1,4 @@
-package test.com.dropbox.kaiken.scoping
+package test.com.dropbox.kaiken.testing
 
 import com.dropbox.kaiken.scoping.AuthRequiredActivity
 

--- a/testing/src/debug/java/test/com/dropbox/kaiken/testing/TestAuthRequiredBroadcastReceiver.kt
+++ b/testing/src/debug/java/test/com/dropbox/kaiken/testing/TestAuthRequiredBroadcastReceiver.kt
@@ -1,4 +1,4 @@
-package test.com.dropbox.kaiken.scoping
+package test.com.dropbox.kaiken.testing
 
 import com.dropbox.kaiken.scoping.AuthRequiredBroadcastReceiver
 

--- a/testing/src/debug/java/test/com/dropbox/kaiken/testing/TestAuthRequiredFragment.kt
+++ b/testing/src/debug/java/test/com/dropbox/kaiken/testing/TestAuthRequiredFragment.kt
@@ -1,4 +1,4 @@
-package test.com.dropbox.kaiken.scoping
+package test.com.dropbox.kaiken.testing
 
 import com.dropbox.kaiken.scoping.AuthRequiredFragment
 

--- a/testing/src/debug/java/test/com/dropbox/kaiken/testing/TestSimpleActivity.kt
+++ b/testing/src/debug/java/test/com/dropbox/kaiken/testing/TestSimpleActivity.kt
@@ -1,4 +1,4 @@
-package test.com.dropbox.kaiken.scoping
+package test.com.dropbox.kaiken.testing
 
 /**
  * Simple test activity that does not inherit from any auth aware activities.


### PR DESCRIPTION
Moving some test Activities and Fragments into the testing module so they can be used by clients.

Closes #17 