### PR TITLE
[DO NOT MERGE] Create POF for Anvil as a first class citizen

### DIFF
--- a/annotations/src/main/java/com/dropbox/kaiken/annotation/DaggerInjectable.java
+++ b/annotations/src/main/java/com/dropbox/kaiken/annotation/DaggerInjectable.java
@@ -1,0 +1,12 @@
+package com.dropbox.kaiken.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.TYPE)
+public @interface DaggerInjectable {
+    Class<?> dependency() ;
+}

--- a/annotations/src/main/java/com/dropbox/kaiken/annotation/Injectable.java
+++ b/annotations/src/main/java/com/dropbox/kaiken/annotation/Injectable.java
@@ -26,4 +26,6 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.CLASS)
 @Target(ElementType.TYPE)
-public @interface Injectable {}
+public @interface Injectable {
+    Class<?> COMPONENT();
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ android.useAndroidX=true
 
 # POM
 GROUP = com.dropbox.kaiken
-VERSION_NAME=1.0.5-SNAPSHOT
+VERSION_NAME=1.0.6-SNAPSHOT
 POM_INCEPTION_YEAR = 2020
 
 POM_URL = https://github.com/dropbox/kaiken/

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -16,4 +16,5 @@ dependencies {
 
     implementation deps.javapoet
     implementation deps.kotlinpoet
+    implementation 'com.squareup.anvil:annotations:2.1.0'
 }

--- a/processor/src/main/java/com/dropbox/kaiken/processor/InjectableCommon.kt
+++ b/processor/src/main/java/com/dropbox/kaiken/processor/InjectableCommon.kt
@@ -17,9 +17,10 @@ internal fun generateInjectorInterfaceFileSpec(
     pack: String,
     interfaceName: String,
     paramName: String,
-    targetType: TypeMirror
+    targetType: TypeMirror,
+    className: com.squareup.kotlinpoet.ClassName
 ): JavaFile {
-    val interfaceSpec = generateInjectorInterface(interfaceName, paramName, targetType)
+    val interfaceSpec = generateInjectorInterface(interfaceName, paramName, targetType, className)
 
     return JavaFile.builder(pack, interfaceSpec)
         .addFileComment(GENERATED_BY_TOP_COMMENT)
@@ -29,7 +30,8 @@ internal fun generateInjectorInterfaceFileSpec(
 private fun generateInjectorInterface(
     interfaceName: String,
     paramName: String,
-    targetType: TypeMirror
+    targetType: TypeMirror,
+    className: com.squareup.kotlinpoet.ClassName
 ): TypeSpec {
     val interfaceBuilder = TypeSpec.interfaceBuilder(interfaceName)
 
@@ -40,7 +42,7 @@ private fun generateInjectorInterface(
         .addModifiers(Modifier.PUBLIC)
         .addAnnotation(
             AnnotationSpec.builder(ClassName.get("com.squareup.anvil.annotations","ContributesTo"))
-                .addMember("scope", "\$T.class", ClassName.get("com.example.kaikeninjecterror","AActivityScope"))
+                .addMember("scope", "\$T.class", ClassName.get(className.packageName, className.simpleName))
                 .build())
         .addMethod(
             MethodSpec.methodBuilder("inject")

--- a/processor/src/main/java/com/dropbox/kaiken/processor/InjectableCommon.kt
+++ b/processor/src/main/java/com/dropbox/kaiken/processor/InjectableCommon.kt
@@ -2,6 +2,7 @@ package com.dropbox.kaiken.processor
 
 import com.dropbox.kaiken.Injector
 import com.dropbox.kaiken.processor.internal.GENERATED_BY_TOP_COMMENT
+import com.squareup.javapoet.AnnotationSpec
 import com.squareup.javapoet.ClassName
 import com.squareup.javapoet.JavaFile
 import com.squareup.javapoet.MethodSpec
@@ -37,6 +38,10 @@ private fun generateInjectorInterface(
     return interfaceBuilder
         .addSuperinterface(injectorTypeName)
         .addModifiers(Modifier.PUBLIC)
+        .addAnnotation(
+            AnnotationSpec.builder(ClassName.get("com.squareup.anvil.annotations","ContributesTo"))
+                .addMember("scope", "\$T.class", ClassName.get("com.example.kaikeninjecterror","AActivityScope"))
+                .build())
         .addMethod(
             MethodSpec.methodBuilder("inject")
                 .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)

--- a/processor/src/main/java/com/dropbox/kaiken/processor/InjectableFragmentWriter.kt
+++ b/processor/src/main/java/com/dropbox/kaiken/processor/InjectableFragmentWriter.kt
@@ -58,10 +58,10 @@ internal class InjectableFragmentWriter(
         interfaceName: String,
         fragmentType: TypeMirror
     ) {
-        val interfaceFileSpec = generateInjectorInterfaceFileSpec(
-            pack, interfaceName, "fragment", fragmentType
-        )
-        interfaceFileSpec.writeTo(filer)
+        // val interfaceFileSpec = generateInjectorInterfaceFileSpec(
+        //     pack, interfaceName, "fragment", fragmentType, className
+        // )
+        // interfaceFileSpec.writeTo(filer)
     }
 
     private fun writeExtensionFunctionFile(

--- a/processor/src/main/java/com/dropbox/kaiken/processor/InjectableProcessor.kt
+++ b/processor/src/main/java/com/dropbox/kaiken/processor/InjectableProcessor.kt
@@ -63,21 +63,21 @@ class InjectableProcessor : AbstractProcessor() {
     private fun processInternal(
         roundEnvironment: RoundEnvironment
     ): Boolean {
-        roundEnvironment.getElementsAnnotatedWith(Injectable::class.java).forEach { element ->
-
-            val isClass = element.validateIsClass(messager) {
-                "Only classes can be annotated with ${Injectable::class.java.simpleName}"
-            }
-
-            if (!isClass) {
-                return true
-            }
-
-            // We validated it is a class
-            val typeElement = element as TypeElement
-
-            safeProcessInjectableElement(typeElement, elements)
-        }
+        // roundEnvironment.getElementsAnnotatedWith(Injectable::class.java).forEach { element ->
+        //
+        //     val isClass = element.validateIsClass(messager) {
+        //         "Only classes can be annotated with ${Injectable::class.java.simpleName}"
+        //     }
+        //
+        //     if (!isClass) {
+        //         return true
+        //     }
+        //
+        //     // We validated it is a class
+        //     val typeElement = element as TypeElement
+        //
+        //     safeProcessInjectableElement(typeElement, elements)
+        // }
 
         roundEnvironment.getElementsAnnotatedWith(DaggerInjectable::class.java).forEach { element ->
 

--- a/processor/src/main/java/com/dropbox/kaiken/processor/InjectableProcessor.kt
+++ b/processor/src/main/java/com/dropbox/kaiken/processor/InjectableProcessor.kt
@@ -76,17 +76,20 @@ class InjectableProcessor : AbstractProcessor() {
             // We validated it is a class
             val typeElement = element as TypeElement
 
-            safeProcessInjectableElement(typeElement)
+            safeProcessInjectableElement(typeElement, elements)
         }
 
         return true
     }
 
-    private fun safeProcessInjectableElement(typeElement: TypeElement) {
+    private fun safeProcessInjectableElement(
+        typeElement: TypeElement,
+        elements: Elements
+    ) {
         try {
             when {
                 typeElement.isAndroidActivity() -> {
-                    processInjectableActivity(typeElement)
+                    processInjectableActivity(typeElement,elements)
                 }
                 typeElement.isAndroidFragment() -> {
                     processInjectableFragment(typeElement)
@@ -104,14 +107,17 @@ class InjectableProcessor : AbstractProcessor() {
         }
     }
 
-    private fun processInjectableActivity(typeElement: TypeElement) {
+    private fun processInjectableActivity(
+        typeElement: TypeElement,
+        elements: Elements
+    ) {
         val annotatedActivity = InjectableAnnotatedActivity(typeElement)
 
         if (!annotatedActivityValidator.isValid(annotatedActivity)) {
             return
         }
 
-        annotatedActivityWriter.write(annotatedActivity)
+        annotatedActivityWriter.write(annotatedActivity, elements)
     }
 
     private fun processInjectableFragment(typeElement: TypeElement) {

--- a/processor/src/main/java/com/dropbox/kaiken/processor/InjectableProcessor.kt
+++ b/processor/src/main/java/com/dropbox/kaiken/processor/InjectableProcessor.kt
@@ -146,7 +146,7 @@ class InjectableProcessor : AbstractProcessor() {
         annotatedFragmentWriter.write(annotatedFragment)
     }
 
-    override fun getSupportedAnnotationTypes() = setOf(DaggerInjectable::class.java.canonicalName)
+    override fun getSupportedAnnotationTypes() = setOf(DaggerInjectable::class.java.canonicalName, Injectable::class.java.canonicalName)
 
     override fun getSupportedSourceVersion(): SourceVersion = SourceVersion.latestSupported()
 }

--- a/processor/src/main/java/com/dropbox/kaiken/processor/InjectableProcessor.kt
+++ b/processor/src/main/java/com/dropbox/kaiken/processor/InjectableProcessor.kt
@@ -1,5 +1,6 @@
 package com.dropbox.kaiken.processor
 
+import com.dropbox.kaiken.annotation.DaggerInjectable
 import com.dropbox.kaiken.annotation.Injectable
 import com.dropbox.kaiken.processor.internal.error
 import com.dropbox.kaiken.processor.internal.isAndroidActivity
@@ -22,7 +23,6 @@ import javax.lang.model.util.Types
 @AutoService(Processor::class)
 @IncrementalAnnotationProcessor(IncrementalAnnotationProcessorType.ISOLATING)
 class InjectableProcessor : AbstractProcessor() {
-
     private lateinit var filer: Filer
     private lateinit var messager: Messager
     private lateinit var elements: Elements
@@ -79,6 +79,23 @@ class InjectableProcessor : AbstractProcessor() {
             safeProcessInjectableElement(typeElement, elements)
         }
 
+        roundEnvironment.getElementsAnnotatedWith(DaggerInjectable::class.java).forEach { element ->
+
+            // val isClass = element.validateIsClass(messager) {
+            //     "Only classes can be annotated with ${DaggerInjectable::class.java.simpleName}"
+            // }
+            //
+            // if (!isClass) {
+            //     return true
+            // }
+            //
+            // // We validated it is a class
+            val typeElement = element as TypeElement
+
+            safeProcessInjectableElement(typeElement, elements)
+        }
+
+
         return true
     }
 
@@ -91,9 +108,9 @@ class InjectableProcessor : AbstractProcessor() {
                 typeElement.isAndroidActivity() -> {
                     processInjectableActivity(typeElement,elements)
                 }
-                typeElement.isAndroidFragment() -> {
-                    processInjectableFragment(typeElement)
-                }
+                // typeElement.isAndroidFragment() -> {
+                //     processInjectableFragment(typeElement)
+                // }
                 else -> {
                     messager.error(
                         typeElement,
@@ -109,13 +126,12 @@ class InjectableProcessor : AbstractProcessor() {
 
     private fun processInjectableActivity(
         typeElement: TypeElement,
-        elements: Elements
-    ) {
+        elements: Elements) {
         val annotatedActivity = InjectableAnnotatedActivity(typeElement)
 
-        if (!annotatedActivityValidator.isValid(annotatedActivity)) {
-            return
-        }
+        // if (!annotatedActivityValidator.isValid(annotatedActivity)) {
+        //     return
+        // }
 
         annotatedActivityWriter.write(annotatedActivity, elements)
     }
@@ -130,7 +146,7 @@ class InjectableProcessor : AbstractProcessor() {
         annotatedFragmentWriter.write(annotatedFragment)
     }
 
-    override fun getSupportedAnnotationTypes() = setOf(Injectable::class.java.canonicalName)
+    override fun getSupportedAnnotationTypes() = setOf(DaggerInjectable::class.java.canonicalName)
 
     override fun getSupportedSourceVersion(): SourceVersion = SourceVersion.latestSupported()
 }


### PR DESCRIPTION
So here's the thing, anvil and kaiken injectable did not work well together. @rallat made a project proving this https://github.com/rallat/kaikenInjectError

Primarily the problem is using KAPT to generate an interface that we extend and run Anvil compiler plugin on, Anvil compiler plugin generates dagger annotations and then KAPT runs again. This simply does not work. The interface that we generate is not seen by Dagger OR with correct error types true is not seen by Anvil.  This is not the fault of either library, more the going from KAPT to Compiler Plugin to KAPT.  

The solution was to directly generate what Anvil needs. By that I mean we generate with`@ContributesTo` annotationed interfaces.  Next, I added a COMPONENT value to the Injectable annotation. This allowed me to generate the injector resolver boilerplate as well. Here's what a user experience looks like now:
```kotlin
//user tells us what they want in user scope
@ContributesTo(AUserScope::class)
interface LaunchDependencies {
    fun getLifecycleLogger(): LifecycleLogger
}
//user tells us what their FeatureComponent is called
@Injectable(COMPONENT=MyActivityComponent::class)
class LaunchActivity : AppCompatActivity(), AuthRequiredActivity, InjectorHolder<LaunchActivityInjector> {
    @Inject
    lateinit var lifecycleLogger: LifecycleLogger

    override fun onCreate(savedInstanceState: Bundle?) {
        super.onCreate(savedInstanceState)
        inject()
    }

    override fun getInjectorFactory(): InjectorFactory<LaunchActivityInjector> = injector()
}
//we generate the rest
//generated
@ContributesTo(
    scope = AActivityScope.class
)
public interface LaunchActivityInjector extends Injector {
  void inject(LaunchActivity activity);
}

fun LaunchActivity.inject() {
  val activityInjector: LaunchActivityInjector = this.locateInjector()
  activityInjector.inject(this)
}

fun DependencyProviderResolver.injector(): InjectorFactory<LaunchActivityInjector> = object :
    InjectorFactory<LaunchActivityInjector> {
  override fun createInjector() =
      DaggerMyActivityComponent.factory().create(resolveDependencyProvider()) as
      LaunchActivityInjector
}
```

The code is definitely POF but let me know what y'all think
