### PR TITLE
Add test case where injector holder is a Dagger component

### DIFF
--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -3,6 +3,8 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
 dependencies {
+    implementation deps.dagger2
+    kaptDebug deps.dagger2_compiler
     implementation deps.androidx_fragment
     implementation deps.appcompat
     implementation deps.kotlinStdLib
@@ -22,4 +24,7 @@ dependencies {
     androidTestImplementation deps.truth
 
     androidTestImplementation project(':testing')
+}
+kapt {
+    correctErrorTypes = true
 }

--- a/integration-tests/src/androidTest/java/com/dropbox/kaiken/integration_tests/runtime/TestInjectableAnnotation.kt
+++ b/integration-tests/src/androidTest/java/com/dropbox/kaiken/integration_tests/runtime/TestInjectableAnnotation.kt
@@ -33,7 +33,7 @@ class TestInjectableAnnotation {
         injectorHolderScenario = ActivityScenario.launch(TestInjectorHolderActivity::class.java)
 
         injectorHolderScenario!!.onActivity { activity ->
-            assertThat(activity.message).isNull()
+            assertThat(activity.message).isEmpty()
 
             // WHEN
             activity.testInject()
@@ -53,7 +53,7 @@ class TestInjectableAnnotation {
             val fragment = TestSimpleFragment()
             activity.addFragment(fragment)
 
-            assertThat(fragment.message).isNull()
+            assertThat(fragment.message).isEmpty()
 
             // WHEN
             fragment.testInject()
@@ -74,7 +74,7 @@ class TestInjectableAnnotation {
                 val fragment = TestSimpleFragment()
                 activity.addFragment(fragment)
 
-                assertThat(fragment.message).isNull()
+                assertThat(fragment.message).isEmpty()
 
                 // WHEN
                 fragment.testInject()
@@ -98,7 +98,7 @@ class TestInjectableAnnotation {
             val fragment = TestInjectorHolderFragment()
             activity.addFragment(fragment)
 
-            assertThat(fragment.message).isNull()
+            assertThat(fragment.message).isEmpty()
 
             // WHEN
             fragment.testInject()
@@ -117,7 +117,7 @@ class TestInjectableAnnotation {
             val fragment = TestInjectorHolderFragment()
             activity.addFragment(fragment)
 
-            assertThat(fragment.message).isNull()
+            assertThat(fragment.message).isEmpty()
 
             // WHEN
             fragment.testInject()
@@ -137,7 +137,7 @@ class TestInjectableAnnotation {
 
         // GIVEN
         injectorHolderScenario!!.onActivity { activity ->
-            assertThat(activity.message).isNull()
+            assertThat(activity.message).isEmpty()
 
             injectorBeforeRotation = activity.locateInjector()
 
@@ -150,7 +150,7 @@ class TestInjectableAnnotation {
 
         // THEN
         injectorHolderScenario!!.onActivity { activity ->
-            assertThat(activity.message).isNull()
+            assertThat(activity.message).isEmpty()
 
             injectorAfterRotation = activity.locateInjector()
 

--- a/integration-tests/src/androidTest/java/com/dropbox/kaiken/integration_tests/testing/TestKaikenTestRule.kt
+++ b/integration-tests/src/androidTest/java/com/dropbox/kaiken/integration_tests/testing/TestKaikenTestRule.kt
@@ -21,10 +21,10 @@ class TestKaikenTestRule {
 
     @get:Rule
     var kaikenTestRule: KaikenTestRule = KaikenTestRule(
-        injectorFactoryOverrides = mapOf(
-            TestInjectorHolderActivity::class to OverriddenInjectorFactory(),
-            TestInjectorHolderFragment::class to OverriddenInjectorFactory()
-        )
+            injectorFactoryOverrides = mapOf(
+                    TestInjectorHolderActivity::class to OverriddenInjectorFactory(),
+                    TestInjectorHolderFragment::class to OverriddenInjectorFactory()
+            )
     )
 
     @After
@@ -44,9 +44,7 @@ class TestKaikenTestRule {
             activity.testInject()
 
             // THEN
-            assertThat(activity.message).isEqualTo(
-                    messageActivity
-            )
+            assertThat(activity.message).isEqualTo(messageActivity)
         }
     }
 
@@ -66,9 +64,7 @@ class TestKaikenTestRule {
             fragment.testInject()
 
             // THEN
-            assertThat(fragment.message).isEqualTo(
-                messageFragment
-            )
+            assertThat(fragment.message).isEqualTo(messageFragment)
         }
     }
 
@@ -110,7 +106,7 @@ class TestKaikenTestRule {
                     messageActivity
             )
             assertThat(fragment.message).isEqualTo(
-                messageFragment
+                    messageFragment
             )
         }
     }
@@ -160,9 +156,9 @@ class OverriddenInjectorFactory : InjectorFactory<TestInjectorHolderActivityInje
 }
 
 class OverriddenTestInjectorHolder :
-    TestInjectorHolderActivityInjector,
-    TestInjectorHolderFragmentInjector,
-    TestSimpleFragmentInjector {
+        TestInjectorHolderActivityInjector,
+        TestInjectorHolderFragmentInjector,
+        TestSimpleFragmentInjector {
     override fun inject(activity: TestInjectorHolderActivity) {
         activity.message = messageActivity
     }

--- a/integration-tests/src/androidTest/java/com/dropbox/kaiken/integration_tests/testing/TestKaikenTestRule.kt
+++ b/integration-tests/src/androidTest/java/com/dropbox/kaiken/integration_tests/testing/TestKaikenTestRule.kt
@@ -20,12 +20,13 @@ class TestKaikenTestRule {
     private var simplerScenario: ActivityScenario<TestSimpleActivity>? = null
 
     @get:Rule
-    var kaikenTestRule: KaikenTestRule = KaikenTestRule(
+    var kaikenTestRule: KaikenTestRule =
+        KaikenTestRule(
             injectorFactoryOverrides = mapOf(
-                    TestInjectorHolderActivity::class to OverriddenInjectorFactory(),
-                    TestInjectorHolderFragment::class to OverriddenInjectorFactory()
+                TestInjectorHolderActivity::class to OverriddenInjectorFactory(),
+                TestInjectorHolderFragment::class to OverriddenInjectorFactory()
             )
-    )
+        )
 
     @After
     fun teardown() {
@@ -103,10 +104,10 @@ class TestKaikenTestRule {
 
             // THEN
             assertThat(fragment.message).isNotEqualTo(
-                    messageActivity
+                messageActivity
             )
             assertThat(fragment.message).isEqualTo(
-                    messageFragment
+                messageFragment
             )
         }
     }
@@ -156,9 +157,9 @@ class OverriddenInjectorFactory : InjectorFactory<TestInjectorHolderActivityInje
 }
 
 class OverriddenTestInjectorHolder :
-        TestInjectorHolderActivityInjector,
-        TestInjectorHolderFragmentInjector,
-        TestSimpleFragmentInjector {
+    TestInjectorHolderActivityInjector,
+    TestInjectorHolderFragmentInjector,
+    TestSimpleFragmentInjector {
     override fun inject(activity: TestInjectorHolderActivity) {
         activity.message = messageActivity
     }

--- a/integration-tests/src/androidTest/java/com/dropbox/kaiken/integration_tests/testing/TestKaikenTestRuleComponentAsInjectorHolder.kt
+++ b/integration-tests/src/androidTest/java/com/dropbox/kaiken/integration_tests/testing/TestKaikenTestRuleComponentAsInjectorHolder.kt
@@ -20,7 +20,7 @@ class TestKaikenTestRuleComponentAsInjectorHolder {
     var kaikenTestRule: KaikenTestRule = KaikenTestRule(
         injectorFactoryOverrides = mapOf(
             TestInjectorHolderActivity::class to OverriddenInjectorFactoryWithDaggerActivity(),
-                TestInjectorHolderFragmentWithDagger::class to OverriddenInjectorFactoryWithDagger()
+            TestInjectorHolderFragmentWithDagger::class to OverriddenInjectorFactoryWithDagger()
         )
     )
 
@@ -154,13 +154,13 @@ class TestKaikenTestRuleComponentAsInjectorHolder {
 
 class OverriddenInjectorFactoryWithDagger : InjectorFactory<TestComponent> {
     override fun createInjector(): TestComponent {
-        return DaggerTestComponent.builder().dependencies(object: Dependencies {}).build()
+        return DaggerTestComponent.builder().dependencies(object : Dependencies {}).build()
     }
 }
 
 class OverriddenInjectorFactoryWithDaggerActivity : InjectorFactory<TestComponent> {
     override fun createInjector(): TestComponent {
-        return DaggerTestComponent.builder().dependencies(object: Dependencies {
+        return DaggerTestComponent.builder().dependencies(object : Dependencies {
             override val messages: String
                 get() = "activity"
         }).build()

--- a/integration-tests/src/androidTest/java/com/dropbox/kaiken/integration_tests/testing/TestKaikenTestRule_AuthAwareFragment.kt
+++ b/integration-tests/src/androidTest/java/com/dropbox/kaiken/integration_tests/testing/TestKaikenTestRule_AuthAwareFragment.kt
@@ -36,7 +36,7 @@ class TestKaikenTestRule {
             val fragment = TestAuthAwareFragment()
             activity.addFragment(fragment)
 
-            assertThat(fragment.message).isNull()
+            assertThat(fragment.message).isEmpty()
 
             // WHEN
             fragment.testInject()

--- a/integration-tests/src/debug/java/com/dropbox/kaiken/integration_tests/TestAuthAwareFragment.kt
+++ b/integration-tests/src/debug/java/com/dropbox/kaiken/integration_tests/TestAuthAwareFragment.kt
@@ -1,5 +1,6 @@
 package com.dropbox.kaiken.integration_tests
 
+import android.os.Bundle
 import androidx.fragment.app.Fragment
 import com.dropbox.kaiken.annotation.Injectable
 import com.dropbox.kaiken.scoping.AuthAwareFragment
@@ -8,7 +9,12 @@ import javax.inject.Inject
 @Injectable
 class TestAuthAwareFragment : Fragment(), AuthAwareFragment {
     @Inject
-    var message: String? = null
+    lateinit var message: String
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        message = ""
+    }
 
     fun testInject() {
         inject()

--- a/integration-tests/src/debug/java/com/dropbox/kaiken/integration_tests/TestInjectorHolderActivity.kt
+++ b/integration-tests/src/debug/java/com/dropbox/kaiken/integration_tests/TestInjectorHolderActivity.kt
@@ -11,9 +11,10 @@ import javax.inject.Inject
 @Injectable
 class TestInjectorHolderActivity : AppCompatActivity(), InjectorHolder<TestInjectorHolderActivityInjector> {
     @Inject
-    var message: String? = null
+    lateinit var message: String
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        message = ""
         if (android.os.Build.VERSION.SDK_INT != 26) {
             setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT)
         }

--- a/integration-tests/src/debug/java/com/dropbox/kaiken/integration_tests/TestInjectorHolderFragment.kt
+++ b/integration-tests/src/debug/java/com/dropbox/kaiken/integration_tests/TestInjectorHolderFragment.kt
@@ -1,5 +1,6 @@
 package com.dropbox.kaiken.integration_tests
 
+import android.os.Bundle
 import androidx.fragment.app.Fragment
 import com.dropbox.kaiken.annotation.Injectable
 import com.dropbox.kaiken.runtime.InjectorFactory
@@ -9,9 +10,14 @@ import javax.inject.Inject
 @Injectable
 class TestInjectorHolderFragment : Fragment(), InjectorHolder<TestInjectorHolderFragmentInjector> {
     @Inject
-    var message: String? = null
+    lateinit var message: String
 
     override fun getInjectorFactory() = fakeInjectorFactory()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        message = ""
+    }
 
     fun testInject() {
         inject()

--- a/integration-tests/src/debug/java/com/dropbox/kaiken/integration_tests/TestInjectorHolderFragmentWithDagger.kt
+++ b/integration-tests/src/debug/java/com/dropbox/kaiken/integration_tests/TestInjectorHolderFragmentWithDagger.kt
@@ -1,0 +1,52 @@
+package com.dropbox.kaiken.integration_tests
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import com.dropbox.kaiken.annotation.Injectable
+import com.dropbox.kaiken.runtime.InjectorFactory
+import com.dropbox.kaiken.runtime.InjectorHolder
+import com.dropbox.kaiken.runtime.findInjector
+import com.dropbox.kaiken.scoping.AuthAwareFragment
+import com.dropbox.kaiken.scoping.DependencyProviderResolver
+import dagger.Component
+import javax.inject.Inject
+
+@Injectable
+class TestInjectorHolderFragmentWithDagger : AuthAwareFragment, Fragment(), InjectorHolder<TestComponent> {
+    @Inject
+    lateinit var message: String
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        message = ""
+    }
+
+    fun testInject() {
+        inject()
+    }
+
+    override fun getInjectorFactory(): InjectorFactory<TestComponent> = daggerInjector()
+
+}
+
+@Component(dependencies = [Dependencies::class])
+interface TestComponent : TestInjectorHolderFragmentWithDaggerInjector, Dependencies, TestInjectorHolderActivityInjector, TestSimpleFragmentInjector
+
+interface Dependencies {
+    val messages: String
+        get() = "test"
+}
+
+fun DependencyProviderResolver.daggerInjector() =
+        object : InjectorFactory<TestComponent> {
+            override fun createInjector() =
+                    buildPhotosInternalComponent(resolveDependencyProvider())
+        }
+
+private fun buildPhotosInternalComponent(
+        dependencies: TestComponent
+): TestComponent = DaggerTestComponent.builder().build()
+
+
+internal fun Fragment.providePhotosPresenterDependencies():
+        Dependencies = findInjector<TestComponent>()

--- a/integration-tests/src/debug/java/com/dropbox/kaiken/integration_tests/TestInjectorHolderFragmentWithDagger.kt
+++ b/integration-tests/src/debug/java/com/dropbox/kaiken/integration_tests/TestInjectorHolderFragmentWithDagger.kt
@@ -24,9 +24,7 @@ class TestInjectorHolderFragmentWithDagger : AuthAwareFragment, Fragment(), Inje
     fun testInject() {
         inject()
     }
-
     override fun getInjectorFactory(): InjectorFactory<TestComponent> = daggerInjector()
-
 }
 
 @Component(dependencies = [Dependencies::class])
@@ -38,15 +36,14 @@ interface Dependencies {
 }
 
 fun DependencyProviderResolver.daggerInjector() =
-        object : InjectorFactory<TestComponent> {
-            override fun createInjector() =
-                    buildPhotosInternalComponent(resolveDependencyProvider())
-        }
+    object : InjectorFactory<TestComponent> {
+        override fun createInjector() =
+            buildPhotosInternalComponent(resolveDependencyProvider())
+    }
 
 private fun buildPhotosInternalComponent(
-        dependencies: TestComponent
-): TestComponent = DaggerTestComponent.builder().build()
-
+    dependencies: TestComponent
+): TestComponent = DaggerTestComponent.builder().dependencies(dependencies).build()
 
 internal fun Fragment.providePhotosPresenterDependencies():
-        Dependencies = findInjector<TestComponent>()
+    Dependencies = findInjector<TestComponent>()

--- a/integration-tests/src/debug/java/com/dropbox/kaiken/integration_tests/TestSimpleFragment.kt
+++ b/integration-tests/src/debug/java/com/dropbox/kaiken/integration_tests/TestSimpleFragment.kt
@@ -1,5 +1,6 @@
 package com.dropbox.kaiken.integration_tests
 
+import android.os.Bundle
 import androidx.fragment.app.Fragment
 import com.dropbox.kaiken.annotation.Injectable
 import javax.inject.Inject
@@ -7,7 +8,12 @@ import javax.inject.Inject
 @Injectable
 class TestSimpleFragment : Fragment() {
     @Inject
-    var message: String? = null
+    lateinit var message: String
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        message = ""
+    }
 
     fun testInject() {
         inject()

--- a/scoping/src/androidTest/java/com/dropbox/kaiken/scoping/AuthAwareBroadcastReceiverTest.kt
+++ b/scoping/src/androidTest/java/com/dropbox/kaiken/scoping/AuthAwareBroadcastReceiverTest.kt
@@ -48,7 +48,7 @@ class AuthAwareBroadcastReceiverTest {
             context, intent
         )
 
-        assertThat(resolvedDependencies).isNull()
+        assertThat(resolvedDependencies).isEmpty()
     }
 
     @Test

--- a/scoping/src/androidTest/java/com/dropbox/kaiken/scoping/AuthAwareFragmentTest.kt
+++ b/scoping/src/androidTest/java/com/dropbox/kaiken/scoping/AuthAwareFragmentTest.kt
@@ -63,7 +63,7 @@ class AuthAwareFragmentTest {
     private fun ActivityScenario<out TestAuthAwareScopedActivity>
     .assertFragmentCanResolveAppScopedDependency() {
         onActivity { activity ->
-            assertThat(activity.onCreateExceptionThrown).isNull()
+            assertThat(activity.onCreateExceptionThrown).isEmpty()
             val testObject = activity.findTestAuthAwareFragment()
 
             val resolvedDependencies = testObject.resolvedDependencies
@@ -80,7 +80,7 @@ class AuthAwareFragmentTest {
     private fun ActivityScenario<out TestAuthAwareScopedActivity>
     .assertFragmentCanResolveUserScopedDependency() {
         onActivity { activity ->
-            assertThat(activity.onCreateExceptionThrown).isNull()
+            assertThat(activity.onCreateExceptionThrown).isEmpty()
             val testObject = activity.findTestAuthAwareFragment()
 
             val resolvedDependencies = testObject.resolvedDependencies

--- a/scoping/src/androidTest/java/com/dropbox/kaiken/scoping/AuthScopeOwnersFragmentsTest.kt
+++ b/scoping/src/androidTest/java/com/dropbox/kaiken/scoping/AuthScopeOwnersFragmentsTest.kt
@@ -148,7 +148,7 @@ class AuthScopeOwnersFragmentsTest {
     .assertFragmentCanResolveAppScopedDependency() {
         onActivity { activity ->
             val testObject = activity.findTestAuthAwareScopedFragment()
-            assertThat(testObject.onAttachExceptionThrown).isNull()
+            assertThat(testObject.onAttachExceptionThrown).isEmpty()
 
             val resolvedDependencies = testObject.resolvedDependencies
             assertThat(resolvedDependencies).isNotNull()
@@ -162,7 +162,7 @@ class AuthScopeOwnersFragmentsTest {
     .assertFragmentCanResolveUserScopedDependency() {
         onActivity { activity ->
             val testObject = activity.findTestAuthAwareScopedFragment()
-            assertThat(testObject.onAttachExceptionThrown).isNull()
+            assertThat(testObject.onAttachExceptionThrown).isEmpty()
 
             val resolvedDependencies = testObject.resolvedDependencies
             assertThat(resolvedDependencies).isNotNull()

--- a/scoping/src/androidTest/java/com/dropbox/kaiken/scoping/ViewingUserSelectorTest.kt
+++ b/scoping/src/androidTest/java/com/dropbox/kaiken/scoping/ViewingUserSelectorTest.kt
@@ -21,7 +21,7 @@ class ViewingUserSelectorTest {
 
         // THEN
         assertThat(hasResult).isFalse()
-        assertThat(getResult).isNull()
+        assertThat(getResult).isEmpty()
     }
 
     @Test(expected = IllegalArgumentException::class)
@@ -64,7 +64,7 @@ class ViewingUserSelectorTest {
 
         // THEN
         assertThat(hasResult).isFalse()
-        assertThat(getResult).isNull()
+        assertThat(getResult).isEmpty()
     }
 
     @Test(expected = IllegalArgumentException::class)

--- a/scoping/src/test/java/com/dropbox/kaiken/scoping/UserServicesProviderTest.kt
+++ b/scoping/src/test/java/com/dropbox/kaiken/scoping/UserServicesProviderTest.kt
@@ -28,7 +28,7 @@ class UserServicesProviderTest {
         val userServices = testObject.provideUserServicesOf(viewingUserSelector)
 
         // THEN
-        assertThat(userServices).isEmpty()
+        assertThat(userServices).isNull()
     }
 }
 

--- a/scoping/src/test/java/com/dropbox/kaiken/scoping/UserServicesProviderTest.kt
+++ b/scoping/src/test/java/com/dropbox/kaiken/scoping/UserServicesProviderTest.kt
@@ -28,7 +28,7 @@ class UserServicesProviderTest {
         val userServices = testObject.provideUserServicesOf(viewingUserSelector)
 
         // THEN
-        assertThat(userServices).isNull()
+        assertThat(userServices).isEmpty()
     }
 }
 


### PR DESCRIPTION
There is a bit of noise because I had to change the message to lateinit and that made me replace `isNull` by `isEmpty`. Please ignore that.

The important files to check are `TestInjectorHolderFragmentWithDagger` the `InjectHolder` is a `TestComponent` which is a Dagger generated class. This is similar to how we use it internally.
The test file is `TestKaikenTestRuleComponentAsInjectorHolder`