### PR TITLE
Upgrade Anvil and use the built-in mechanism to sync sources. 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         classpath "org.jetbrains.kotlinx:atomicfu-gradle-plugin:${versions.atomicFuPlugin}"
         classpath "com.vanniktech:gradle-maven-publish-plugin:0.13.0"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:0.10.1"
-        classpath "com.squareup.anvil:gradle-plugin:2.3.6"
+        classpath "com.squareup.anvil:gradle-plugin:2.3.9"
     }
 }
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -7,7 +7,7 @@ ext.versions = [
         ktlint            : '0.39.0',
 
         // Plugins
-        androidGradlePlugin         : '4.0.0',
+        androidGradlePlugin         : '4.1.0',
         dokkaGradlePlugin           : '0.10.0',
         ktlintGradle                : '9.1.1',
         spotlessGradlePlugin        : '3.26.1',

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -28,11 +28,8 @@ dependencies {
     androidTestImplementation project(':testing')
 }
 
-// This allows the generated source sets to be resolved in IntelliJ and only runs when we're syncing in the IDE
-if (System.getProperty("idea.sync.active") != null) {
-    android.libraryVariants.all { variant ->
-        android.sourceSets.getByName("main").java.srcDirs += new File(project.buildDir, "anvil/src-gen-${variant.name}")
-    }
+anvil {
+    syncGeneratedSources = true
 }
 
 android {

--- a/runtime/api/runtime.api
+++ b/runtime/api/runtime.api
@@ -2,8 +2,6 @@ public final class com/dropbox/kaiken/runtime/BuildConfig {
 	public static final field BUILD_TYPE Ljava/lang/String;
 	public static final field DEBUG Z
 	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
-	public static final field VERSION_CODE I
-	public static final field VERSION_NAME Ljava/lang/String;
 	public fun <init> ()V
 }
 

--- a/scoping-navgraph/api/scoping-navgraph.api
+++ b/scoping-navgraph/api/scoping-navgraph.api
@@ -17,8 +17,6 @@ public final class com/dropbox/kaiken/scoping_navgraph/BuildConfig {
 	public static final field BUILD_TYPE Ljava/lang/String;
 	public static final field DEBUG Z
 	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
-	public static final field VERSION_CODE I
-	public static final field VERSION_NAME Ljava/lang/String;
 	public fun <init> ()V
 }
 

--- a/scoping/api/scoping.api
+++ b/scoping/api/scoping.api
@@ -119,8 +119,6 @@ public final class com/dropbox/kaiken/scoping/BuildConfig {
 	public static final field BUILD_TYPE Ljava/lang/String;
 	public static final field DEBUG Z
 	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
-	public static final field VERSION_CODE I
-	public static final field VERSION_NAME Ljava/lang/String;
 	public fun <init> ()V
 }
 

--- a/testing/api/testing.api
+++ b/testing/api/testing.api
@@ -2,8 +2,6 @@ public final class com/dropbox/kaiken/testing/BuildConfig {
 	public static final field BUILD_TYPE Ljava/lang/String;
 	public static final field DEBUG Z
 	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
-	public static final field VERSION_CODE I
-	public static final field VERSION_NAME Ljava/lang/String;
 	public fun <init> ()V
 }
 


### PR DESCRIPTION
This feature requires a newer version of AGP, which itself requires a newer version of Gradle. Both dependencies have been upgraded as well.