### PR TITLE
Remove guards on injector read

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Artifacts are hosted on **Maven Central**.
 ###### Latest version:
 
 ```groovy
-def kaiken_version = "2.0.1"
+def kaiken_version = "2.0.0"
 ```
 
 ###### Add the dependency to your `build.gradle`:

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Artifacts are hosted on **Maven Central**.
 ###### Latest version:
 
 ```groovy
-def kaiken_version = "2.0.1-SNAPSHOT"
+def kaiken_version = "2.0.1"
 ```
 
 ###### Add the dependency to your `build.gradle`:

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Artifacts are hosted on **Maven Central**.
 ###### Latest version:
 
 ```groovy
-def kaiken_version = "2.0.0"
+def kaiken_version = "2.0.1-SNAPSHOT"
 ```
 
 ###### Add the dependency to your `build.gradle`:

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ android.useAndroidX=true
 
 # POM
 GROUP = com.dropbox.kaiken
-VERSION_NAME=2.0.0
+VERSION_NAME=2.0.1-SNAPSHOT
 POM_INCEPTION_YEAR = 2020
 
 POM_URL = https://github.com/dropbox/kaiken/

--- a/runtime/src/main/java/com/dropbox/kaiken/runtime/FragmentHelper.kt
+++ b/runtime/src/main/java/com/dropbox/kaiken/runtime/FragmentHelper.kt
@@ -15,7 +15,6 @@ fun <InjectorType : Injector> Fragment.findInjector(): InjectorType {
     return injectorHolder.locateInjector()
 }
 
-@OptIn(InternalKaikenApi::class)
 @Suppress("UNCHECKED_CAST")
 fun <InjectorType : Injector> Fragment.findInjectorHolder(): InjectorHolder<InjectorType>? {
     return when {
@@ -25,11 +24,8 @@ fun <InjectorType : Injector> Fragment.findInjectorHolder(): InjectorHolder<Inje
         activity is InjectorHolder<*> -> {
             activity as InjectorHolder<InjectorType>
         }
-        BuildConfig.DEBUG && KaikenRuntimeTestUtils.testMode -> {
-            KaikenRuntimeTestUtils.injectorHolderOverrideFor(this::class)
-        }
         else -> {
-            null
+            KaikenRuntimeTestUtils.injectorHolderOverrideFor(this::class)
         }
     }
 }

--- a/runtime/src/main/java/com/dropbox/kaiken/runtime/FragmentHelper.kt
+++ b/runtime/src/main/java/com/dropbox/kaiken/runtime/FragmentHelper.kt
@@ -2,7 +2,6 @@ package com.dropbox.kaiken.runtime
 
 import androidx.fragment.app.Fragment
 import com.dropbox.kaiken.Injector
-import com.dropbox.kaiken.annotation.InternalKaikenApi
 
 @Suppress("UNCHECKED_CAST", "IfThenToElvis")
 fun <InjectorType : Injector> Fragment.findInjector(): InjectorType {

--- a/runtime/src/main/java/com/dropbox/kaiken/runtime/InjectorHolder.kt
+++ b/runtime/src/main/java/com/dropbox/kaiken/runtime/InjectorHolder.kt
@@ -15,11 +15,8 @@ interface InjectorHolder<InjectorType : Injector> :
 
     private fun locateInjectorInternal(): InjectorType {
         val kclass: KClass<out InjectorHolder<*>> = this::class
-        var injectorFactory: InjectorFactory<InjectorType>? = null
-
-        if (BuildConfig.DEBUG) {
-            injectorFactory = KaikenRuntimeTestUtils.injectorFactoryOverrideFor(kclass)
-        }
+        var injectorFactory: InjectorFactory<InjectorType>? =
+            KaikenRuntimeTestUtils.injectorFactoryOverrideFor(kclass)
 
         if (injectorFactory == null) {
             injectorFactory = this.getInjectorFactory()

--- a/runtime/src/main/java/com/dropbox/kaiken/runtime/KaikenRuntimeTestUtils.kt
+++ b/runtime/src/main/java/com/dropbox/kaiken/runtime/KaikenRuntimeTestUtils.kt
@@ -48,6 +48,7 @@ object KaikenRuntimeTestUtils {
         injectorHolderKClass: KClass<out InjectorHolder<*>>,
         injectorFactory: InjectorFactory<InjectorType>
     ) {
+        require(testMode)
         injectorFactoryOverrides[injectorHolderKClass] = injectorFactory
     }
 
@@ -66,6 +67,7 @@ object KaikenRuntimeTestUtils {
         injectableClass: KClass<out Fragment>,
         injector: InjectorType
     ) {
+        require(testMode)
         injectorOverrides[injectableClass] = StaticInjectorHolder(injector)
     }
 
@@ -83,10 +85,6 @@ object KaikenRuntimeTestUtils {
 private class StaticInjectorHolder<InjectorType : Injector>(
     private val injector: InjectorType
 ) : InjectorHolder<InjectorType> {
-
-    init {
-        require(testMode)
-    }
 
     private val viewModelStore: ViewModelStore = ViewModelStore()
 


### PR DESCRIPTION
Currently, we're checking the `BuildConfig.DEBUG` flag if we should be reading from the injector factor and injector overrides. This code works if you're running the code using the debug variant of Kaiken, however, as code published to Maven Central is the `release` variant, this check will always fail.

These overrides are only set in the `testing` module and there's a check to ensure `require(testMode)` passes before we allow the overrides to be set.