### PR TITLE
Increase metaspace memory for Gradle

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,9 @@
 # The flag is false by default if it is not specified.
 android.useAndroidX=true
 
+# https://github.com/Kotlin/dokka/issues/1405
+org.gradle.jvmargs=-XX:MaxMetaspaceSize=2G
+
 # POM
 GROUP = com.dropbox.kaiken
 VERSION_NAME=2.0.1-SNAPSHOT


### PR DESCRIPTION
When we run the publish action, it fails in dokka hitting OOM https://github.com/dropbox/kaiken/runs/4243132113?check_suite_focus=true#step:4:1193

The issue in https://github.com/Kotlin/dokka/issues/1405 suggests to increase the memory to 2g