### PR TITLE
Automatically close and release in Nexus for releases

### DIFF
--- a/.github/workflows/ci_test_and_publish.yml
+++ b/.github/workflows/ci_test_and_publish.yml
@@ -32,6 +32,12 @@ jobs:
           ENCRYPT_KEY: ${{ secrets.ENCRYPT_KEY }}
           SIGNING_ID: ${{ secrets.SIGNING_ID }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+
+      - name: Publish release
+        run: ./gradlew closeAndReleaseRepository --no-daemon --no-parallel
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
       
       - name: Clean up Artifacts
         if: always()


### PR DESCRIPTION
Uses the vannitech Gradle Publish Plugin to automatically close and release artifacts in Nexus https://github.com/vanniktech/gradle-maven-publish-plugin#releasing