### PR TITLE
Remove autocommit code

### DIFF
--- a/.github/workflows/ci_test_and_publish.yml
+++ b/.github/workflows/ci_test_and_publish.yml
@@ -43,21 +43,6 @@ jobs:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
 
-      - name: Prepare next development version
-        run: |
-          sed -i -e "s/${VERSION_NAME}/${VERSION_NAME}-SNAPSHOT/g" gradle.properties
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          git commit -m "Prepare next development version" -a
-        if: "!endsWith(env.VERSION_NAME, '-SNAPSHOT')"
-
-      - name: Push changes
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ github.ref }}
-        if: "!endsWith(env.VERSION_NAME, '-SNAPSHOT')"
-
   test:
     runs-on: macos-latest
     timeout-minutes: 30


### PR DESCRIPTION
It's potentially unsafe to have code automatically pushed into the repo and we need to give the actions bot write permissions to the repo