### PR TITLE
Treat kotlin compiler warnings as errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ allprojects {
         targetCompatibility = JavaVersion.VERSION_1_8
 
         kotlinOptions {
+            allWarningsAsErrors = true
             jvmTarget = '1.8'
             freeCompilerArgs += ["-Xopt-in=kotlin.RequiresOptIn", '-Xjvm-default=compatibility']
         }

--- a/processor/src/main/java/com/dropbox/kaiken/processor/InjectableCodeGenerator.kt
+++ b/processor/src/main/java/com/dropbox/kaiken/processor/InjectableCodeGenerator.kt
@@ -32,7 +32,7 @@ class InjectableCodeGenerator : CodeGenerator {
         ACTIVITY, FRAGMENT, INVALID
     }
 
-    @KotlinPoetJavaPoetPreview
+    @OptIn(KotlinPoetJavaPoetPreview::class)
     override fun generateCode(
         codeGenDir: File,
         module: ModuleDescriptor,
@@ -81,8 +81,7 @@ class InjectableCodeGenerator : CodeGenerator {
                 generateFragmentFileSpec(
                     packageName,
                     "${className.simpleName}Injector",
-                    className,
-                    true
+                    className
                 )
             createGeneratedFile(
                 codeGenDir = codeGenDir,

--- a/processor/src/main/java/com/dropbox/kaiken/processor/InjectableFragmentWriter.kt
+++ b/processor/src/main/java/com/dropbox/kaiken/processor/InjectableFragmentWriter.kt
@@ -76,7 +76,6 @@ internal fun generateFragmentFileSpec(
     pack: String,
     interfaceName: String,
     fragmentType: TypeName,
-    shouldGenerateAuthAww: Boolean,
 ): FileSpec {
     val extensionFunctionSpec = generateInjectExtensionFunction(interfaceName, fragmentType)
     val interfaceSpec = generateInjectInterfaceSpec(interfaceName, fragmentType)

--- a/scoping-navgraph/api/scoping-navgraph.api
+++ b/scoping-navgraph/api/scoping-navgraph.api
@@ -1,16 +1,25 @@
 public final class com/dropbox/kaiken/scoping_navgraph/AuthAwareNavHostFragment : androidx/navigation/fragment/NavHostFragment, com/dropbox/kaiken/scoping/AuthAwareFragment {
 	public fun <init> ()V
 	public fun _$_clearFindViewByIdCache ()V
+	public fun finishIfInvalidAuth ()Z
+	public fun getViewingUserSelector ()Lcom/dropbox/kaiken/scoping/ViewingUserSelector;
+	public fun resolveDependencyProvider ()Ljava/lang/Object;
 }
 
 public final class com/dropbox/kaiken/scoping_navgraph/AuthOptionalNavHostFragment : androidx/navigation/fragment/NavHostFragment, com/dropbox/kaiken/scoping/AuthOptionalFragment {
 	public fun <init> ()V
 	public fun _$_clearFindViewByIdCache ()V
+	public fun finishIfInvalidAuth ()Z
+	public fun getAuthRequired ()Z
+	public fun resolveDependencyProvider ()Ljava/lang/Object;
 }
 
 public final class com/dropbox/kaiken/scoping_navgraph/AuthRequiredNavHostFragment : androidx/navigation/fragment/NavHostFragment, com/dropbox/kaiken/scoping/AuthRequiredFragment {
 	public fun <init> ()V
 	public fun _$_clearFindViewByIdCache ()V
+	public fun finishIfInvalidAuth ()Z
+	public fun getAuthRequired ()Z
+	public fun resolveDependencyProvider ()Ljava/lang/Object;
 }
 
 public final class com/dropbox/kaiken/scoping_navgraph/BuildConfig {

--- a/scoping/api/scoping.api
+++ b/scoping/api/scoping.api
@@ -11,7 +11,7 @@ public abstract interface class com/dropbox/kaiken/scoping/AppTeardownHelper {
 
 public abstract interface class com/dropbox/kaiken/scoping/AuthAwareBroadcastReceiver {
 	public abstract fun getAuthRequired ()Z
-	public fun onReceiveResolveDependencyProvider (Landroid/content/Context;Landroid/content/Intent;)Ljava/lang/Object;
+	public abstract fun onReceiveResolveDependencyProvider (Landroid/content/Context;Landroid/content/Intent;)Ljava/lang/Object;
 }
 
 public final class com/dropbox/kaiken/scoping/AuthAwareBroadcastReceiver$DefaultImpls {
@@ -19,11 +19,11 @@ public final class com/dropbox/kaiken/scoping/AuthAwareBroadcastReceiver$Default
 }
 
 public abstract interface class com/dropbox/kaiken/scoping/AuthAwareFragment : com/dropbox/kaiken/scoping/DependencyProviderResolver {
-	public fun finishIfInvalidAuth ()Z
+	public abstract fun finishIfInvalidAuth ()Z
 	public abstract fun getActivity ()Landroidx/fragment/app/FragmentActivity;
 	public abstract fun getParentFragment ()Landroidx/fragment/app/Fragment;
-	public fun getViewingUserSelector ()Lcom/dropbox/kaiken/scoping/ViewingUserSelector;
-	public fun resolveDependencyProvider ()Ljava/lang/Object;
+	public abstract fun getViewingUserSelector ()Lcom/dropbox/kaiken/scoping/ViewingUserSelector;
+	public abstract fun resolveDependencyProvider ()Ljava/lang/Object;
 }
 
 public final class com/dropbox/kaiken/scoping/AuthAwareFragment$DefaultImpls {
@@ -33,10 +33,10 @@ public final class com/dropbox/kaiken/scoping/AuthAwareFragment$DefaultImpls {
 }
 
 public abstract interface class com/dropbox/kaiken/scoping/AuthAwareScopeOwnerActivity : androidx/lifecycle/ViewModelStoreOwner, com/dropbox/kaiken/scoping/DependencyProviderResolver {
-	public fun finishIfInvalidAuth ()Z
+	public abstract fun finishIfInvalidAuth ()Z
 	public abstract fun getAuthRequired ()Z
-	public fun getViewingUserSelector ()Lcom/dropbox/kaiken/scoping/ViewingUserSelector;
-	public fun resolveDependencyProvider ()Ljava/lang/Object;
+	public abstract fun getViewingUserSelector ()Lcom/dropbox/kaiken/scoping/ViewingUserSelector;
+	public abstract fun resolveDependencyProvider ()Ljava/lang/Object;
 }
 
 public final class com/dropbox/kaiken/scoping/AuthAwareScopeOwnerActivity$DefaultImpls {
@@ -46,10 +46,10 @@ public final class com/dropbox/kaiken/scoping/AuthAwareScopeOwnerActivity$Defaul
 }
 
 public abstract interface class com/dropbox/kaiken/scoping/AuthAwareScopeOwnerFragment : com/dropbox/kaiken/scoping/DependencyProviderResolver {
-	public fun finishIfInvalidAuth ()Z
+	public abstract fun finishIfInvalidAuth ()Z
 	public abstract fun getActivity ()Landroidx/fragment/app/FragmentActivity;
 	public abstract fun getAuthRequired ()Z
-	public fun resolveDependencyProvider ()Ljava/lang/Object;
+	public abstract fun resolveDependencyProvider ()Ljava/lang/Object;
 }
 
 public final class com/dropbox/kaiken/scoping/AuthAwareScopeOwnerFragment$DefaultImpls {
@@ -58,7 +58,7 @@ public final class com/dropbox/kaiken/scoping/AuthAwareScopeOwnerFragment$Defaul
 }
 
 public abstract interface class com/dropbox/kaiken/scoping/AuthOptionalActivity : com/dropbox/kaiken/scoping/AuthAwareScopeOwnerActivity, com/dropbox/kaiken/scoping/DependencyProviderResolver {
-	public fun getAuthRequired ()Z
+	public abstract fun getAuthRequired ()Z
 }
 
 public final class com/dropbox/kaiken/scoping/AuthOptionalActivity$DefaultImpls {
@@ -69,7 +69,7 @@ public final class com/dropbox/kaiken/scoping/AuthOptionalActivity$DefaultImpls 
 }
 
 public abstract interface class com/dropbox/kaiken/scoping/AuthOptionalBroadcastReceiver : com/dropbox/kaiken/scoping/AuthAwareBroadcastReceiver {
-	public fun getAuthRequired ()Z
+	public abstract fun getAuthRequired ()Z
 }
 
 public final class com/dropbox/kaiken/scoping/AuthOptionalBroadcastReceiver$DefaultImpls {
@@ -78,7 +78,7 @@ public final class com/dropbox/kaiken/scoping/AuthOptionalBroadcastReceiver$Defa
 }
 
 public abstract interface class com/dropbox/kaiken/scoping/AuthOptionalFragment : com/dropbox/kaiken/scoping/AuthAwareScopeOwnerFragment {
-	public fun getAuthRequired ()Z
+	public abstract fun getAuthRequired ()Z
 }
 
 public final class com/dropbox/kaiken/scoping/AuthOptionalFragment$DefaultImpls {
@@ -88,8 +88,8 @@ public final class com/dropbox/kaiken/scoping/AuthOptionalFragment$DefaultImpls 
 }
 
 public abstract interface class com/dropbox/kaiken/scoping/AuthRequiredActivity : com/dropbox/kaiken/scoping/AuthAwareScopeOwnerActivity, com/dropbox/kaiken/scoping/DependencyProviderResolver {
-	public fun getAuthRequired ()Z
-	public fun requireViewingUserSelector ()Lcom/dropbox/kaiken/scoping/ViewingUserSelector;
+	public abstract fun getAuthRequired ()Z
+	public abstract fun requireViewingUserSelector ()Lcom/dropbox/kaiken/scoping/ViewingUserSelector;
 }
 
 public final class com/dropbox/kaiken/scoping/AuthRequiredActivity$DefaultImpls {
@@ -101,7 +101,7 @@ public final class com/dropbox/kaiken/scoping/AuthRequiredActivity$DefaultImpls 
 }
 
 public abstract interface class com/dropbox/kaiken/scoping/AuthRequiredBroadcastReceiver : com/dropbox/kaiken/scoping/AuthAwareBroadcastReceiver {
-	public fun getAuthRequired ()Z
+	public abstract fun getAuthRequired ()Z
 }
 
 public final class com/dropbox/kaiken/scoping/AuthRequiredBroadcastReceiver$DefaultImpls {
@@ -110,7 +110,7 @@ public final class com/dropbox/kaiken/scoping/AuthRequiredBroadcastReceiver$Defa
 }
 
 public abstract interface class com/dropbox/kaiken/scoping/AuthRequiredFragment : com/dropbox/kaiken/scoping/AuthAwareScopeOwnerFragment {
-	public fun getAuthRequired ()Z
+	public abstract fun getAuthRequired ()Z
 }
 
 public final class com/dropbox/kaiken/scoping/AuthRequiredFragment$DefaultImpls {
@@ -139,7 +139,7 @@ public abstract interface class com/dropbox/kaiken/scoping/UserServices : com/dr
 }
 
 public abstract interface class com/dropbox/kaiken/scoping/UserServicesProvider {
-	public fun provideUserServicesOf (Lcom/dropbox/kaiken/scoping/ViewingUserSelector;)Lcom/dropbox/kaiken/scoping/UserServices;
+	public abstract fun provideUserServicesOf (Lcom/dropbox/kaiken/scoping/ViewingUserSelector;)Lcom/dropbox/kaiken/scoping/UserServices;
 	public abstract fun provideUserServicesOf (Ljava/lang/String;)Lcom/dropbox/kaiken/scoping/UserServices;
 }
 

--- a/scoping/src/main/java/com/dropbox/kaiken/scoping/AuthAwareBroadcastReceiver.kt
+++ b/scoping/src/main/java/com/dropbox/kaiken/scoping/AuthAwareBroadcastReceiver.kt
@@ -16,7 +16,6 @@ interface AuthAwareBroadcastReceiver {
      *
      * Should be called from [BroadcastReceiver#onReceive].
      */
-    @JvmDefault
     fun <T> onReceiveResolveDependencyProvider(context: Context, intent: Intent): T? {
         val scopedServicesProvider = this.locateScopedServicesProvider(context)
         val viewingUserSelector = intent.getViewingUserSelector()

--- a/scoping/src/main/java/com/dropbox/kaiken/scoping/AuthAwareFragment.kt
+++ b/scoping/src/main/java/com/dropbox/kaiken/scoping/AuthAwareFragment.kt
@@ -41,7 +41,6 @@ interface AuthAwareFragment : DependencyProviderResolver {
      *
      * @throws IllegalArgumentException if the parent activity is not [AuthAwareScopeOwnerActivity].
      */
-    @JvmDefault
     fun getViewingUserSelector(): ViewingUserSelector? =
         requireAuthAwareActivity().getViewingUserSelector()
 
@@ -59,7 +58,6 @@ interface AuthAwareFragment : DependencyProviderResolver {
      *
      * @return whether or not the activity has been finished.
      */
-    @JvmDefault
     override fun finishIfInvalidAuth(): Boolean {
         val parentFragment = parentFragmentAsDependencyResolver()
 
@@ -74,7 +72,6 @@ interface AuthAwareFragment : DependencyProviderResolver {
      * Implementation of [resolveDependencyProvider] that fetches the dependencies from its
      * parent fragment if any or from its parent activity.
      */
-    @JvmDefault
     override fun <T> resolveDependencyProvider(): T {
         val parentFragment = parentFragmentAsDependencyResolver()
 

--- a/scoping/src/main/java/com/dropbox/kaiken/scoping/AuthAwareScopeOwnerActivity.kt
+++ b/scoping/src/main/java/com/dropbox/kaiken/scoping/AuthAwareScopeOwnerActivity.kt
@@ -15,7 +15,6 @@ interface AuthAwareScopeOwnerActivity : DependencyProviderResolver, ViewModelSto
 
     val authRequired: Boolean
 
-    @JvmDefault
     fun getViewingUserSelector(): ViewingUserSelector? =
         locateAuthHelper().viewingUserSelector
 
@@ -24,7 +23,6 @@ interface AuthAwareScopeOwnerActivity : DependencyProviderResolver, ViewModelSto
      *
      * [finishIfInvalidAuth] must be called before calling this method.
      */
-    @JvmDefault
     override fun <T> resolveDependencyProvider(): T =
         locateAuthHelper().resolveDependencyProvider()
 
@@ -39,7 +37,6 @@ interface AuthAwareScopeOwnerActivity : DependencyProviderResolver, ViewModelSto
      *
      * @return whether or not the activity has been finished.
      */
-    @JvmDefault
     override fun finishIfInvalidAuth(): Boolean {
         val activity = (this as ComponentActivity)
         val authHelper = locateAuthHelper()

--- a/scoping/src/main/java/com/dropbox/kaiken/scoping/AuthAwareScopeOwnerFragment.kt
+++ b/scoping/src/main/java/com/dropbox/kaiken/scoping/AuthAwareScopeOwnerFragment.kt
@@ -31,7 +31,6 @@ interface AuthAwareScopeOwnerFragment : DependencyProviderResolver {
      *
      * [finishIfInvalidAuth] must be called before calling this method.
      */
-    @JvmDefault
     override fun <T> resolveDependencyProvider(): T =
         locateAuthHelper().resolveDependencyProvider()
 
@@ -47,7 +46,6 @@ interface AuthAwareScopeOwnerFragment : DependencyProviderResolver {
      *
      * @return whether or not the activity has been finished.
      */
-    @JvmDefault
     override fun finishIfInvalidAuth(): Boolean {
         val authHelper = locateAuthHelper()
 

--- a/scoping/src/main/java/com/dropbox/kaiken/scoping/AuthOptionalActivity.kt
+++ b/scoping/src/main/java/com/dropbox/kaiken/scoping/AuthOptionalActivity.kt
@@ -4,7 +4,6 @@ package com.dropbox.kaiken.scoping
  * An activity that does not require a user to be logged in.
  */
 interface AuthOptionalActivity : AuthAwareScopeOwnerActivity, DependencyProviderResolver {
-    @JvmDefault
     override val authRequired: Boolean
         get() = false
 }

--- a/scoping/src/main/java/com/dropbox/kaiken/scoping/AuthOptionalBroadcastReceiver.kt
+++ b/scoping/src/main/java/com/dropbox/kaiken/scoping/AuthOptionalBroadcastReceiver.kt
@@ -4,7 +4,6 @@ package com.dropbox.kaiken.scoping
  * An broadcast received that does not require a user to be logged in.
  */
 interface AuthOptionalBroadcastReceiver : AuthAwareBroadcastReceiver {
-    @JvmDefault
     override val authRequired: Boolean
         get() = false
 }

--- a/scoping/src/main/java/com/dropbox/kaiken/scoping/AuthOptionalFragment.kt
+++ b/scoping/src/main/java/com/dropbox/kaiken/scoping/AuthOptionalFragment.kt
@@ -7,7 +7,6 @@ package com.dropbox.kaiken.scoping
  * to be an [AuthAwareScopeOwnerActivity].
  */
 interface AuthOptionalFragment : AuthAwareScopeOwnerFragment {
-    @JvmDefault
     override val authRequired: Boolean
         get() = false
 }

--- a/scoping/src/main/java/com/dropbox/kaiken/scoping/AuthRequiredActivity.kt
+++ b/scoping/src/main/java/com/dropbox/kaiken/scoping/AuthRequiredActivity.kt
@@ -4,10 +4,8 @@ package com.dropbox.kaiken.scoping
  * An activity that requires a user to be logged in.
  */
 interface AuthRequiredActivity : AuthAwareScopeOwnerActivity, DependencyProviderResolver {
-    @JvmDefault
     override val authRequired: Boolean
         get() = true
 
-    @JvmDefault
     fun requireViewingUserSelector(): ViewingUserSelector = checkNotNull(getViewingUserSelector())
 }

--- a/scoping/src/main/java/com/dropbox/kaiken/scoping/AuthRequiredBroadcastReceiver.kt
+++ b/scoping/src/main/java/com/dropbox/kaiken/scoping/AuthRequiredBroadcastReceiver.kt
@@ -4,7 +4,6 @@ package com.dropbox.kaiken.scoping
  * An broadcast received that requires a user to be logged in.
  */
 interface AuthRequiredBroadcastReceiver : AuthAwareBroadcastReceiver {
-    @JvmDefault
     override val authRequired: Boolean
         get() = true
 }

--- a/scoping/src/main/java/com/dropbox/kaiken/scoping/AuthRequiredFragment.kt
+++ b/scoping/src/main/java/com/dropbox/kaiken/scoping/AuthRequiredFragment.kt
@@ -7,7 +7,6 @@ package com.dropbox.kaiken.scoping
  * to be an [AuthAwareScopeOwnerActivity].
  */
 interface AuthRequiredFragment : AuthAwareScopeOwnerFragment {
-    @JvmDefault
     override val authRequired: Boolean
         get() = true
 }

--- a/scoping/src/main/java/com/dropbox/kaiken/scoping/UserServicesProvider.kt
+++ b/scoping/src/main/java/com/dropbox/kaiken/scoping/UserServicesProvider.kt
@@ -15,7 +15,6 @@ interface UserServicesProvider {
      * Returns the user services for a given viewing user selector or`null` if they are not
      * available.
      */
-    @JvmDefault
     fun provideUserServicesOf(viewingUserSelector: ViewingUserSelector): UserServices? =
         provideUserServicesOf(viewingUserSelector.userId)
 }

--- a/skeleton/api/skeleton.api
+++ b/skeleton/api/skeleton.api
@@ -89,6 +89,7 @@ public final class com/dropbox/kaiken/skeleton/core/AppSkeletonInitializer : com
 	public fun getUserServicesFactory ()Lkotlin/jvm/functions/Function2;
 	public fun getUserServicesProvider ()Lcom/dropbox/kaiken/scoping/UserServicesProvider;
 	public fun provideAppServices ()Lcom/dropbox/kaiken/scoping/AppServices;
+	public fun provideUserServicesOf (Lcom/dropbox/kaiken/scoping/ViewingUserSelector;)Lcom/dropbox/kaiken/scoping/UserServices;
 	public fun provideUserServicesOf (Ljava/lang/String;)Lcom/dropbox/kaiken/scoping/UserServices;
 	public fun setUserServicesProvider (Lcom/dropbox/kaiken/scoping/UserServicesProvider;)V
 }
@@ -108,6 +109,7 @@ public final class com/dropbox/kaiken/skeleton/core/AppSkeletonScopedServices : 
 	public fun getUserServicesFactory ()Lkotlin/jvm/functions/Function2;
 	public fun getUserServicesProvider ()Lcom/dropbox/kaiken/scoping/UserServicesProvider;
 	public fun provideAppServices ()Lcom/dropbox/kaiken/scoping/AppServices;
+	public fun provideUserServicesOf (Lcom/dropbox/kaiken/scoping/ViewingUserSelector;)Lcom/dropbox/kaiken/scoping/UserServices;
 	public fun provideUserServicesOf (Ljava/lang/String;)Lcom/dropbox/kaiken/scoping/UserServices;
 	public fun setUserServicesProvider (Lcom/dropbox/kaiken/scoping/UserServicesProvider;)V
 }
@@ -149,6 +151,7 @@ public abstract interface class com/dropbox/kaiken/skeleton/core/KaikenUserServi
 public final class com/dropbox/kaiken/skeleton/core/KaikenUserServicesProvider : com/dropbox/kaiken/skeleton/core/SkeletonUserServicesProvider {
 	public fun <init> (Lcom/dropbox/kaiken/scoping/AppServices;Lkotlin/jvm/functions/Function2;Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/CoroutineScope;)V
 	public final fun provideUserServices (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun provideUserServicesOf (Lcom/dropbox/kaiken/scoping/ViewingUserSelector;)Lcom/dropbox/kaiken/scoping/UserServices;
 	public fun provideUserServicesOf (Ljava/lang/String;)Lcom/dropbox/kaiken/scoping/UserServices;
 }
 
@@ -215,6 +218,7 @@ public abstract class com/dropbox/kaiken/skeleton/core/SkeletonOwnerApplication 
 	public fun getUserServicesProvider ()Lcom/dropbox/kaiken/scoping/UserServicesProvider;
 	public fun onCreate ()V
 	public fun provideAppServices ()Lcom/dropbox/kaiken/scoping/AppServices;
+	public fun provideUserServicesOf (Lcom/dropbox/kaiken/scoping/ViewingUserSelector;)Lcom/dropbox/kaiken/scoping/UserServices;
 	public fun provideUserServicesOf (Ljava/lang/String;)Lcom/dropbox/kaiken/scoping/UserServices;
 	public fun setScopedServices (Lcom/dropbox/kaiken/skeleton/core/AppSkeletonScopedServices;)V
 	public fun setUserServicesProvider (Lcom/dropbox/kaiken/scoping/UserServicesProvider;)V

--- a/skeleton/src/main/java/com/dropbox/kaiken/skeleton/core/KaikenAppServices.kt
+++ b/skeleton/src/main/java/com/dropbox/kaiken/skeleton/core/KaikenAppServices.kt
@@ -7,6 +7,7 @@ import com.dropbox.kaiken.skeleton.usermanagement.UserStore
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.ContributesTo
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.MainScope
 import javax.inject.Inject
@@ -30,6 +31,7 @@ interface CoroutineScopeBindings {
 class RealCoroutineScopes @Inject constructor() : CoroutineScopes {
     override val mainScope: CoroutineScope
         get() = MainScope()
+    @OptIn(DelicateCoroutinesApi::class)
     override val globalScope: CoroutineScope
         get() = GlobalScope
 }

--- a/skeleton/src/test/java/com/dropbox/kaiken/skeleton/scoping/fugazi/FakeCoroutineScopes.kt
+++ b/skeleton/src/test/java/com/dropbox/kaiken/skeleton/scoping/fugazi/FakeCoroutineScopes.kt
@@ -5,9 +5,11 @@ import com.dropbox.kaiken.skeleton.core.RealCoroutineScopes
 import com.dropbox.kaiken.skeleton.scoping.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import javax.inject.Inject
 
+@OptIn(DelicateCoroutinesApi::class)
 @ContributesBinding(AppScope::class, replaces = [RealCoroutineScopes::class])
 class FakeCoroutineScopes @Inject constructor() : CoroutineScopes {
     override val mainScope: CoroutineScope


### PR DESCRIPTION
Turns on `allWarningsAsErrors = true` in an `allProjects` block. 

Most of the errors were around a `JvmDefault` which we already have as a `-Xjvm-default=compatibility`. 