### PR TITLE
AuthRequiredScope cannot access PresenterProvider

### DIFF
--- a/sample/sample-with-di/app/src/main/AndroidManifest.xml
+++ b/sample/sample-with-di/app/src/main/AndroidManifest.xml
@@ -18,6 +18,8 @@
         </activity>
 
         <activity android:name="com.dropbox.kaiken.sample.advancedsample.app.LoggedInActivity"></activity>
+
+        <activity android:name="com.dropbox.kaiken.sample.advancedsample.helloworldfeature.HomeActivity"></activity>
     </application>
 
 </manifest>

--- a/sample/sample-with-di/app/src/main/java/com/dropbox/kaiken/sample/advancedsample/app/AdvancedKaikenSampleApplication.kt
+++ b/sample/sample-with-di/app/src/main/java/com/dropbox/kaiken/sample/advancedsample/app/AdvancedKaikenSampleApplication.kt
@@ -1,6 +1,7 @@
 package com.dropbox.kaiken.sample.advancedsample.app
 
 import android.app.Application
+import com.dropbox.kaiken.sample.advancedsample.helloworldfeature.UserProfile
 import com.dropbox.kaiken.skeleton.core.SkeletonOwnerApplication
 import com.dropbox.kaiken.skeleton.dagger.SdkSpec
 import com.dropbox.kaiken.skeleton.scoping.AppScope

--- a/sample/sample-with-di/app/src/main/java/com/dropbox/kaiken/sample/advancedsample/app/LoginActivity.kt
+++ b/sample/sample-with-di/app/src/main/java/com/dropbox/kaiken/sample/advancedsample/app/LoginActivity.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import com.dropbox.kaiken.sample.advancedsample.helloworldfeature.AuthOptionalComposeActivity
+import com.dropbox.kaiken.sample.advancedsample.helloworldfeature.HomeActivity
 import com.dropbox.kaiken.sample.advancedsample.helloworldfeature.LoginRouter
 import com.dropbox.kaiken.sample.advancedsample.helloworldfeature.setContent
 import com.dropbox.kaiken.scoping.ViewingUserSelector
@@ -27,7 +28,7 @@ class LoginActivity : AuthOptionalComposeActivity() {
 fun getLaunchIntent(
     context: Context,
     userId: String,
-): Intent = Intent(context, LoggedInActivity::class.java).apply {
+): Intent = Intent(context, HomeActivity::class.java).apply {
     putViewingUserSelector(ViewingUserSelector.fromUserId(userId))
 }
 

--- a/sample/sample-with-di/app/src/main/java/com/dropbox/kaiken/sample/advancedsample/app/LoginActivity.kt
+++ b/sample/sample-with-di/app/src/main/java/com/dropbox/kaiken/sample/advancedsample/app/LoginActivity.kt
@@ -18,7 +18,6 @@ import dagger.Provides
 class LoginActivity : AuthOptionalComposeActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        if (finishIfInvalidAuth()) return
         setContent {
             LoginRouter()
         }

--- a/sample/sample-with-di/app/src/main/java/com/dropbox/kaiken/sample/advancedsample/app/UserProfile.kt
+++ b/sample/sample-with-di/app/src/main/java/com/dropbox/kaiken/sample/advancedsample/app/UserProfile.kt
@@ -1,3 +1,0 @@
-package com.dropbox.kaiken.sample.advancedsample.app
-
-data class UserProfile(val userId: String, val name: String)

--- a/sample/sample-with-di/app/src/main/java/com/dropbox/kaiken/sample/advancedsample/app/UserServices.kt
+++ b/sample/sample-with-di/app/src/main/java/com/dropbox/kaiken/sample/advancedsample/app/UserServices.kt
@@ -3,6 +3,7 @@ package com.dropbox.kaiken.sample.advancedsample.app
 import com.dropbox.kaiken.sample.advancedsample.helloworldfeature.HelloWorldMessageProviderUser
 import com.dropbox.kaiken.sample.advancedsample.helloworldfeature.RealWorldMessageProviderUser
 import com.dropbox.kaiken.sample.advancedsample.helloworldfeature.TimeMessageProvider
+import com.dropbox.kaiken.sample.advancedsample.helloworldfeature.UserProfile
 import com.dropbox.kaiken.scoping.UserTeardownHelper
 import com.dropbox.kaiken.skeleton.scoping.AppScope
 import com.dropbox.kaiken.skeleton.scoping.SingleIn

--- a/sample/sample-with-di/helloworldfeature/src/main/java/com/dropbox/kaiken/sample/advancedsample/helloworldfeature/ComposeBindings.kt
+++ b/sample/sample-with-di/helloworldfeature/src/main/java/com/dropbox/kaiken/sample/advancedsample/helloworldfeature/ComposeBindings.kt
@@ -207,7 +207,7 @@ fun AuthAwareScopedComposeActivity.setContent(content: @Composable () -> Unit) {
 
 interface BasePresenter
 
-abstract class Presenter<Event, Model>(
+abstract class Presenter<Event, Model> (
     initialState: Model,
 ) : BasePresenter {
     var model: Model by mutableStateOf(initialState)

--- a/sample/sample-with-di/helloworldfeature/src/main/java/com/dropbox/kaiken/sample/advancedsample/helloworldfeature/ComposeBindings.kt
+++ b/sample/sample-with-di/helloworldfeature/src/main/java/com/dropbox/kaiken/sample/advancedsample/helloworldfeature/ComposeBindings.kt
@@ -1,5 +1,6 @@
 package com.dropbox.kaiken.sample.advancedsample.helloworldfeature
 
+import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.runtime.Composable
@@ -171,7 +172,12 @@ inline fun <reified T : BasePresenter, reified V : Injector> retainAuthedCompone
     }
 }
 
-abstract class AuthAwareScopedComposeActivity : AuthAwareScopeOwnerActivity, ComponentActivity()
+abstract class AuthAwareScopedComposeActivity : AuthAwareScopeOwnerActivity, ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (finishIfInvalidAuth()) return
+    }
+}
 abstract class AuthOptionalComposeActivity : AuthOptionalActivity, AuthAwareScopedComposeActivity()
 abstract class AuthRequiredComposeActivity : AuthRequiredActivity, AuthAwareScopedComposeActivity()
 

--- a/sample/sample-with-di/helloworldfeature/src/main/java/com/dropbox/kaiken/sample/advancedsample/helloworldfeature/HomeActivity.kt
+++ b/sample/sample-with-di/helloworldfeature/src/main/java/com/dropbox/kaiken/sample/advancedsample/helloworldfeature/HomeActivity.kt
@@ -22,10 +22,15 @@ import androidx.navigation.compose.rememberNavController
 import com.dropbox.kaiken.sample_with_di.helloworldfeature.R
 
 
+// * Navigate to a lot of different activities
+// * Screen that has a lot of properties on model that get modified
+// * Screen that loads data on entry and needs a spinner
+// * Screen with a complex list of things
+// *
+
 class HomeActivity: AuthRequiredComposeActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        if (finishIfInvalidAuth()) return
         setContent {
             HomeRouter()
         }

--- a/sample/sample-with-di/helloworldfeature/src/main/java/com/dropbox/kaiken/sample/advancedsample/helloworldfeature/HomeActivity.kt
+++ b/sample/sample-with-di/helloworldfeature/src/main/java/com/dropbox/kaiken/sample/advancedsample/helloworldfeature/HomeActivity.kt
@@ -1,0 +1,80 @@
+package com.dropbox.kaiken.sample.advancedsample.helloworldfeature
+
+import android.os.Bundle
+import androidx.annotation.StringRes
+import androidx.compose.material.BottomNavigation
+import androidx.compose.material.BottomNavigationItem
+import androidx.compose.material.Icon
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.navigation.NavDestination.Companion.hierarchy
+import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
+import com.dropbox.kaiken.sample_with_di.helloworldfeature.R
+
+
+class HomeActivity: AuthRequiredComposeActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (finishIfInvalidAuth()) return
+        setContent {
+            HomeRouter()
+        }
+    }
+}
+
+@Composable
+fun HomeRouter() {
+    val navController = rememberNavController()
+    val tabs = listOf(Tab.Home, Tab.Settings)
+    Scaffold(
+            bottomBar = {
+                BottomNavigation {
+                    val navBackStackEntry by navController.currentBackStackEntryAsState()
+                    val currentDestination = navBackStackEntry?.destination
+
+                    tabs.forEach { screen ->
+                        BottomNavigationItem(
+                                icon = { Icon(screen.icon, contentDescription = null) },
+                                label = { Text(stringResource(screen.titleId)) },
+                                selected = currentDestination?.hierarchy?.any { it.route == screen.route } == true,
+                                onClick = {
+                                    navController.navigate(screen.route) {
+                                        // Pop up to the start destination of the graph to
+                                        // avoid building up a large stack of destinations
+                                        // on the back stack as users select items
+                                        popUpTo(navController.graph.findStartDestination().id) {}
+                                        // Avoid multiple copies of the same destination when
+                                        // reselecting the same item
+                                        launchSingleTop = true
+                                    }
+                                }
+                        )
+                    }
+                }
+            }
+    ) {
+        NavHost(navController = navController, startDestination = "home") {
+            authAwareComposable(Tab.Home.route) { _, presenter: HomePresenter ->
+                HomeScreen(presenter.model)
+            }
+            authAwareComposable(Tab.Settings.route) { _, presenter: HomePresenter ->
+                HomeScreen(presenter.model)
+            }
+        }
+    }
+}
+
+sealed class Tab(val route: String, @StringRes val titleId: Int, val icon: ImageVector) {
+    object Home : Tab("home", R.string.home_tab_title, Icons.Filled.Home)
+    object Settings : Tab("settings", R.string.settings_tab_title, Icons.Filled.Settings)
+}

--- a/sample/sample-with-di/helloworldfeature/src/main/java/com/dropbox/kaiken/sample/advancedsample/helloworldfeature/HomeActivity.kt
+++ b/sample/sample-with-di/helloworldfeature/src/main/java/com/dropbox/kaiken/sample/advancedsample/helloworldfeature/HomeActivity.kt
@@ -26,7 +26,20 @@ import com.dropbox.kaiken.sample_with_di.helloworldfeature.R
 // * Screen that has a lot of properties on model that get modified
 // * Screen that loads data on entry and needs a spinner
 // * Screen with a complex list of things
-// *
+// * Something that needs dependencies at a lower level but not at the higher level
+
+// Asks:
+// * How to do navigation and passing objects between screens
+//   * Usually with identifiers querying local entries etc.
+//   * If there's a case where we want to pass a model that's not persisted
+// * How we deal with transient state
+// * How do we handle deeplinks into a compose activity (deep-link will be auth optional to redirect to login)
+// * Theming dark mode
+// * Managing backstack while traversing different activities with different NavGraphs
+// * Verify Receivers, Services, make sure they play well as intended
+// * Activity Transitions (if there's anything new with Compose)
+//  * Potentially cannot transition
+
 
 class HomeActivity: AuthRequiredComposeActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -69,11 +82,15 @@ fun HomeRouter() {
             }
     ) {
         NavHost(navController = navController, startDestination = "home") {
-            authAwareComposable(Tab.Home.route) { _, presenter: HomePresenter ->
-                HomeScreen(presenter.model)
+            authRequiredComposable(Tab.Home.route) { _, presenter: HomePresenter ->
+                HomeScreen(presenter.model,
+                        { presenter.events.tryEmit(HomePresenter.LoadSomething) }
+                )
             }
-            authAwareComposable(Tab.Settings.route) { _, presenter: HomePresenter ->
-                HomeScreen(presenter.model)
+            authRequiredComposable(Tab.Settings.route) { _, presenter: HomePresenter ->
+                HomeScreen(presenter.model,
+                        { presenter.events.tryEmit(HomePresenter.LoadSomething) }
+                )
             }
         }
     }

--- a/sample/sample-with-di/helloworldfeature/src/main/java/com/dropbox/kaiken/sample/advancedsample/helloworldfeature/HomeScreen.kt
+++ b/sample/sample-with-di/helloworldfeature/src/main/java/com/dropbox/kaiken/sample/advancedsample/helloworldfeature/HomeScreen.kt
@@ -1,0 +1,42 @@
+package com.dropbox.kaiken.sample.advancedsample.helloworldfeature
+
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import com.dropbox.kaiken.skeleton.scoping.AuthOptionalScreenScope
+import com.dropbox.kaiken.skeleton.scoping.AuthRequiredScreenScope
+import com.dropbox.kaiken.skeleton.scoping.SingleIn
+import com.squareup.anvil.annotations.ContributesMultibinding
+import kotlinx.coroutines.flow.collect
+import javax.inject.Inject
+
+abstract class HomePresenter : Presenter<HomePresenter.HomeEvent, HomePresenter.HomeModel>(Loading) {
+    sealed interface HomeEvent
+    object Loaded: HomeEvent
+
+    sealed interface HomeModel
+    object Loading: HomeModel
+    data class UserLoaded(val userId: String, val count: Int): HomeModel
+}
+
+@SingleIn(AuthRequiredScreenScope::class)
+@ContributesMultibinding(
+        AuthRequiredScreenScope::class,
+        boundType = BasePresenter::class
+)
+class RealHomePresenter @Inject constructor() : HomePresenter() {
+    override suspend fun eventHandler(event: HomeEvent) {
+        when (event) {
+            is Loaded -> { }
+        }
+    }
+}
+
+@Composable
+fun HomeScreen(
+        model: HomePresenter.HomeModel
+) {
+    MaterialTheme {
+        Text(model.toString())
+    }
+}

--- a/sample/sample-with-di/helloworldfeature/src/main/java/com/dropbox/kaiken/sample/advancedsample/helloworldfeature/HomeScreen.kt
+++ b/sample/sample-with-di/helloworldfeature/src/main/java/com/dropbox/kaiken/sample/advancedsample/helloworldfeature/HomeScreen.kt
@@ -3,11 +3,9 @@ package com.dropbox.kaiken.sample.advancedsample.helloworldfeature
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import com.dropbox.kaiken.skeleton.scoping.AuthOptionalScreenScope
 import com.dropbox.kaiken.skeleton.scoping.AuthRequiredScreenScope
 import com.dropbox.kaiken.skeleton.scoping.SingleIn
 import com.squareup.anvil.annotations.ContributesMultibinding
-import kotlinx.coroutines.flow.collect
 import javax.inject.Inject
 
 abstract class HomePresenter : Presenter<HomePresenter.HomeEvent, HomePresenter.HomeModel>(Loading) {

--- a/sample/sample-with-di/helloworldfeature/src/main/java/com/dropbox/kaiken/sample/advancedsample/helloworldfeature/LoginRouter.kt
+++ b/sample/sample-with-di/helloworldfeature/src/main/java/com/dropbox/kaiken/sample/advancedsample/helloworldfeature/LoginRouter.kt
@@ -24,7 +24,10 @@ fun LoginRouter() {
             LoginScreen(
                 presenter.model,
                 { submit: LoginPresenter.Submit -> presenter.events.tryEmit(submit) },
-                this.cast<LoginScreenComponent>().intentFactory()
+                { userId: String ->
+                    val intentFactory = this.cast<LoginScreenComponent>().intentFactory()
+                    navController.context.startActivity(intentFactory(navController.context, userId))
+                }
             ) { navController.navigate("forgot_password") }
         }
         authAwareComposable("forgot_password") { _, presenter: ForgotPasswordPresenter ->
@@ -38,8 +41,7 @@ fun LoginRouter() {
 @Preview
 @Composable
 fun previewLoginScreen() {
-    val intentFactory: @JvmSuppressWildcards (Context, String) -> Intent = { _, _ -> Intent() }
-    LoginScreen(model = LoginPresenter.LoginNeeded, onSubmit = {}, intentFactory = intentFactory) {}
+    LoginScreen(model = LoginPresenter.LoginNeeded, onSubmit = {}, onLoggedInSuccess = {}) {}
 }
 
 @Preview

--- a/sample/sample-with-di/helloworldfeature/src/main/java/com/dropbox/kaiken/sample/advancedsample/helloworldfeature/LoginRouter.kt
+++ b/sample/sample-with-di/helloworldfeature/src/main/java/com/dropbox/kaiken/sample/advancedsample/helloworldfeature/LoginRouter.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.NavController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController
 import com.dropbox.kaiken.Injector
@@ -27,6 +28,7 @@ fun LoginRouter() {
                 { userId: String ->
                     val intentFactory = this.cast<LoginScreenComponent>().intentFactory()
                     navController.context.startActivity(intentFactory(navController.context, userId))
+
                 }
             ) { navController.navigate("forgot_password") }
         }

--- a/sample/sample-with-di/helloworldfeature/src/main/java/com/dropbox/kaiken/sample/advancedsample/helloworldfeature/LoginScreen.kt
+++ b/sample/sample-with-di/helloworldfeature/src/main/java/com/dropbox/kaiken/sample/advancedsample/helloworldfeature/LoginScreen.kt
@@ -62,7 +62,7 @@ class RealLoginPresenter @Inject constructor(
 fun LoginScreen(
     model: LoginPresenter.LoginModel,
     onSubmit: (LoginPresenter.Submit) -> Unit,
-    intentFactory: @JvmSuppressWildcards (Context, String) -> Intent,
+    onLoggedInSuccess: (String) -> Unit,
     onClickForgotPassword: () -> Unit
 ) {
     MaterialTheme {
@@ -72,22 +72,10 @@ fun LoginScreen(
                     loginView(onSubmit, onClickForgotPassword)
                 }
                 is LoginPresenter.LoginSuccess -> {
-                    loggedInActivityLauncher(model, intentFactory)
-                    loginView(onSubmit, onClickForgotPassword)
+                    onLoggedInSuccess(model.userId)
                 }
             }
         }
-    }
-}
-
-@Composable
-private fun loggedInActivityLauncher(
-    model: LoginPresenter.LoginSuccess,
-    intentFactory: @JvmSuppressWildcards (Context, String) -> Intent
-) {
-    val context = LocalContext.current
-    LaunchedEffect(key1 = Unit) {
-        context.startActivity(intentFactory(context, model.userId))
     }
 }
 

--- a/sample/sample-with-di/helloworldfeature/src/main/java/com/dropbox/kaiken/sample/advancedsample/helloworldfeature/UserApi.kt
+++ b/sample/sample-with-di/helloworldfeature/src/main/java/com/dropbox/kaiken/sample/advancedsample/helloworldfeature/UserApi.kt
@@ -1,0 +1,23 @@
+package com.dropbox.kaiken.sample.advancedsample.helloworldfeature
+
+import com.dropbox.kaiken.skeleton.scoping.SingleIn
+import com.dropbox.kaiken.skeleton.scoping.UserScope
+import com.squareup.anvil.annotations.ContributesBinding
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+interface UserApi {
+    suspend fun getList(): List<String>
+}
+
+@ContributesBinding(UserScope::class)
+@SingleIn(UserScope::class)
+class RealUserApi @Inject constructor(
+    val userProfile: UserProfile
+) : UserApi {
+    override suspend fun getList(): List<String> {
+        delay(5000)
+        return listOf(userProfile.userId)
+    }
+}

--- a/sample/sample-with-di/helloworldfeature/src/main/java/com/dropbox/kaiken/sample/advancedsample/helloworldfeature/UserProfile.kt
+++ b/sample/sample-with-di/helloworldfeature/src/main/java/com/dropbox/kaiken/sample/advancedsample/helloworldfeature/UserProfile.kt
@@ -1,0 +1,3 @@
+package com.dropbox.kaiken.sample.advancedsample.helloworldfeature
+
+data class UserProfile(val userId: String, val name: String)

--- a/sample/sample-with-di/helloworldfeature/src/main/res/values/strings.xml
+++ b/sample/sample-with-di/helloworldfeature/src/main/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="home_tab_title">Home</string>
+    <string name="settings_tab_title">Settings</string>
+</resources>

--- a/skeleton/src/main/java/com/dropbox/kaiken/skeleton/scoping/SingleIn.kt
+++ b/skeleton/src/main/java/com/dropbox/kaiken/skeleton/scoping/SingleIn.kt
@@ -121,7 +121,6 @@ interface AuthOptionalScreenComponent : Injector {
     parentScope = UserScope::class
 )
 @SingleIn(AuthRequiredScreenScope::class)
-@MergeComponent(AuthOptionalScreenScope::class)
 interface AuthRequiredScreenComponent : Injector {
     @ContributesTo(UserScope::class)
     interface ScreenParentComponent : Injector {

--- a/skeleton/src/main/java/com/dropbox/kaiken/skeleton/scoping/SingleIn.kt
+++ b/skeleton/src/main/java/com/dropbox/kaiken/skeleton/scoping/SingleIn.kt
@@ -16,6 +16,7 @@ import com.dropbox.kaiken.scoping.UserServices
 import com.squareup.anvil.annotations.ContributesSubcomponent
 import com.squareup.anvil.annotations.ContributesTo
 import com.squareup.anvil.annotations.ExperimentalAnvilApi
+import com.squareup.anvil.annotations.MergeComponent
 import dagger.BindsInstance
 import javax.inject.Scope
 import kotlin.reflect.KClass
@@ -120,6 +121,7 @@ interface AuthOptionalScreenComponent : Injector {
     parentScope = UserScope::class
 )
 @SingleIn(AuthRequiredScreenScope::class)
+@MergeComponent(AuthOptionalScreenScope::class)
 interface AuthRequiredScreenComponent : Injector {
     @ContributesTo(UserScope::class)
     interface ScreenParentComponent : Injector {


### PR DESCRIPTION
Please do not merge. This is very early stages of WIP. I ran into a problem where the `retained.cast` for AuthRequiredScope was failing because `Presenter.PresenterProvider` was only scoped to `AuthOptional`. I'm not that familiar with Anvil so I wasn't able to figure out a better solution than to dupe the Presenter. We're explicitly passing `AuthOptionalScope` or `AuthRequiredScope`, so I can't put it into a higher level scope. It probably doesn't belong there anyway. Maybe this could go in `AuthAwareScope`? I don't know the details of the domain well enough to make that call.