### PR TITLE
Prepare for release 2.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 
 ## Version 2.0.3 *(2022-01-12)
+- revert to 1.8 (#129)
+- revert kotlin (#126)
+- Fixes issue with JvmDefault (#125)
+- Update to latest parcelize (#114
+
+## Version 2.0.3 *(2022-01-12)
 - compose sample in LoginFragment.kt (#113)
 - Reactive Scoped Services ([#112](https://github.com/dropbox/kaiken/pull/112))
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Artifacts are hosted on **Maven Central**.
 ###### Latest version:
 
 ```groovy
-def kaiken_version = "2.0.3"
+def kaiken_version = "2.0.4"
 ```
 
 ###### Add the dependency to your `build.gradle`:

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.jvmargs=-XX:MaxMetaspaceSize=2G
 
 # POM
 GROUP = com.dropbox.kaiken
-VERSION_NAME=2.0.4-SNAPSHOT
+VERSION_NAME=2.0.4
 POM_INCEPTION_YEAR = 2020
 
 POM_URL = https://github.com/dropbox/kaiken/


### PR DESCRIPTION
## Version 2.0.3 *(2022-01-12)
- revert to 1.8 (#129)
- revert kotlin (#126)
- Fixes issue with JvmDefault (#125)
- Update to latest parcelize (#114)