### PR TITLE
Get viewing selector to work well with NavDeepLink

### DIFF
--- a/scoping/src/main/java/com/dropbox/kaiken/scoping/ViewingUserSelector.kt
+++ b/scoping/src/main/java/com/dropbox/kaiken/scoping/ViewingUserSelector.kt
@@ -7,8 +7,7 @@ import android.os.Bundle
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 
-private const val BUNDLE_KEY =
-        "com.dropbox.kaiken.skeleton.scoping.VIEWING_USER_SELECTOR_BUNDLE_KEY"
+private const val BUNDLE_KEY = "com.dropbox.kaiken.skeleton.scoping.VIEWING_USER_SELECTOR_BUNDLE_KEY"
 
 private const val DEEP_LINK_EXTRAS = "android-support-nav:controller:deepLinkExtras"
 
@@ -48,8 +47,7 @@ fun Intent.putViewingUserSelector(userSelector: ViewingUserSelector) {
 fun Intent.hasViewingUserSelector() = this.hasExtra(BUNDLE_KEY)
 
 fun Intent.getViewingUserSelector(): ViewingUserSelector? {
-    return extras?.getViewingUserSelector()
-            ?: return getDeepLinkViewingUserSelector()
+    return extras?.getViewingUserSelector() ?: return getDeepLinkViewingUserSelector()
 }
 
 private fun Intent.getDeepLinkViewingUserSelector(): ViewingUserSelector? {

--- a/scoping/src/main/java/com/dropbox/kaiken/scoping/ViewingUserSelector.kt
+++ b/scoping/src/main/java/com/dropbox/kaiken/scoping/ViewingUserSelector.kt
@@ -8,7 +8,9 @@ import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 
 private const val BUNDLE_KEY =
-    "com.dropbox.kaiken.skeleton.scoping.VIEWING_USER_SELECTOR_BUNDLE_KEY"
+        "com.dropbox.kaiken.skeleton.scoping.VIEWING_USER_SELECTOR_BUNDLE_KEY"
+
+private const val DEEP_LINK_EXTRAS = "android-support-nav:controller:deepLinkExtras"
 
 /**
  * Opaque data structure to help identify what is the current viewing user on an activity or
@@ -46,7 +48,13 @@ fun Intent.putViewingUserSelector(userSelector: ViewingUserSelector) {
 fun Intent.hasViewingUserSelector() = this.hasExtra(BUNDLE_KEY)
 
 fun Intent.getViewingUserSelector(): ViewingUserSelector? {
-    return this.extras?.getViewingUserSelector()
+    return extras?.getViewingUserSelector()
+            ?: return getDeepLinkViewingUserSelector()
+}
+
+private fun Intent.getDeepLinkViewingUserSelector(): ViewingUserSelector? {
+    val deepLinkBundle = this.extras?.get(DEEP_LINK_EXTRAS) as Bundle?
+    return deepLinkBundle?.getViewingUserSelector()
 }
 
 fun Intent.requireViewingUserSelector(): ViewingUserSelector {


### PR DESCRIPTION
NavDeepLink nests the extras in a separate bundle. This diff adds ability to extract viewing user selector from that inner bundle