### PR TITLE
Prepare for 3.0.0-alpha01 release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.jvmargs=-XX:MaxMetaspaceSize=2G
 
 # POM
 GROUP = com.dropbox.kaiken
-VERSION_NAME=2.0.7-SNAPSHOT
+VERSION_NAME=3.0.0-alpha01
 POM_INCEPTION_YEAR = 2020
 
 POM_URL = https://github.com/dropbox/kaiken/


### PR DESCRIPTION
We've been iterating quickly and changing APIs frequently. 

For the moment, we'll shift to a 3.0.0 release branch and append with `alpha##` to avoid noise.  

These builds should be treated as untested and will potentially have breaking APIs changes. 