### PR TITLE
Adds  task to future-proof CI reads of version name.

### DIFF
--- a/.github/workflows/ci_test_and_publish.yml
+++ b/.github/workflows/ci_test_and_publish.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Retrieve version
         run: |
-          echo "VERSION_NAME=$(cat gradle.properties | grep -w "VERSION_NAME" | cut -d'=' -f2)" >> $GITHUB_ENV
+          echo "VERSION_NAME=$(./gradlew -q printVersionName)" >> $GITHUB_ENV
 
       - name: Publish release
         run: ./gradlew closeAndReleaseRepository --no-daemon --no-parallel

--- a/build.gradle
+++ b/build.gradle
@@ -80,13 +80,17 @@ subprojects { Project project ->
             }
         }
     }
-}
 
-subprojects {
     apply plugin: 'com.diffplug.gradle.spotless'
     spotless {
         kotlin {
             target 'src/**/*.kt'
         }
+    }
+}
+
+tasks.register("printVersionName") {
+    doLast {
+        println VERSION_NAME
     }
 }


### PR DESCRIPTION
Using Gradle to get the `VERSION_NAME` that Gradle is using to publish the artifact is a safer option than trying to roll our own parsing of properties files.  This should offer a super simple fix without the risk of future breaks due to someone forgetting this weird gotcha.