### PR TITLE
Rename and update license to its parsable by Github.

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,19 +1,3 @@
-Copyright (c) 2020 Dropbox, Inc.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/README.md
+++ b/README.md
@@ -199,3 +199,19 @@ implementation "com.dropbox.kaiken:runtime:${kaiken_version}"
 ```
 
 Please make sure to sign CLA when making a pull request
+
+## License
+
+    Copyright (c) 2020 Dropbox, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.


### PR DESCRIPTION
Making the license a plain text file that matches a standard license format allows Github to parse it to add metadata to the repository like this:

<img width="185" alt="Screen Shot 2022-01-31 at 4 36 50 PM" src="https://user-images.githubusercontent.com/1296750/151884571-4d4a9aaf-8049-436f-9a6c-3bf6d9e6bcec.png">

And more helpful information like this: 

<img width="1202" alt="Screen Shot 2022-01-31 at 4 40 35 PM" src="https://user-images.githubusercontent.com/1296750/151885002-20afd504-ee4d-4405-8c13-c01c36acd942.png">

