### PR TITLE
Remove BuildConfig.DEBUG for AuthHelperStore

### DIFF
--- a/scoping/src/main/java/com/dropbox/kaiken/scoping/internal/AuthHelperStore.kt
+++ b/scoping/src/main/java/com/dropbox/kaiken/scoping/internal/AuthHelperStore.kt
@@ -12,7 +12,6 @@ import com.dropbox.kaiken.scoping.AuthAwareScopeOwnerFragment
 import com.dropbox.kaiken.scoping.ScopedServicesProvider
 import com.dropbox.kaiken.scoping.ViewingUserSelector
 import com.dropbox.kaiken.scoping.getViewingUserSelector
-import com.dropbox.kaiken.skeleton.scoping.BuildConfig
 
 internal fun AuthAwareScopeOwnerActivity.locateAuthHelperStore(): AuthHelperStore {
     val activity = (this as ComponentActivity)
@@ -32,14 +31,6 @@ fun AuthAwareBroadcastReceiver.locateScopedServicesProvider(
 
 private fun ComponentActivity.locateAuthHelperStore(authRequired: Boolean): AuthHelperStore {
     val viewingUserSelector = intent.getViewingUserSelector()
-
-    if (BuildConfig.DEBUG) {
-        KaikenScopingTestUtils.getAuthHelperStoreTestOverride(viewingUserSelector)
-            ?.let { override ->
-                return override
-            }
-    }
-
     val appServicesProvider = locateScopedServicesProvider()
 
     return locateAuthHelperStore(appServicesProvider, viewingUserSelector, authRequired)
@@ -47,14 +38,6 @@ private fun ComponentActivity.locateAuthHelperStore(authRequired: Boolean): Auth
 
 private fun Fragment.locateAuthHelperStore(authRequired: Boolean): AuthHelperStore {
     val viewingUserSelector = arguments?.getViewingUserSelector()
-
-    if (BuildConfig.DEBUG) {
-        KaikenScopingTestUtils.getAuthHelperStoreTestOverride(viewingUserSelector)
-            ?.let { override ->
-                return override
-            }
-    }
-
     val context = requireActivity()
     val scopedServicesProvider = context.locateScopedServicesProvider()
 

--- a/scoping/src/main/java/com/dropbox/kaiken/scoping/internal/AuthHelperStore.kt
+++ b/scoping/src/main/java/com/dropbox/kaiken/scoping/internal/AuthHelperStore.kt
@@ -31,6 +31,12 @@ fun AuthAwareBroadcastReceiver.locateScopedServicesProvider(
 
 private fun ComponentActivity.locateAuthHelperStore(authRequired: Boolean): AuthHelperStore {
     val viewingUserSelector = intent.getViewingUserSelector()
+
+    KaikenScopingTestUtils.getAuthHelperStoreTestOverride(viewingUserSelector)
+        ?.let { override ->
+            return override
+        }
+
     val appServicesProvider = locateScopedServicesProvider()
 
     return locateAuthHelperStore(appServicesProvider, viewingUserSelector, authRequired)
@@ -38,6 +44,12 @@ private fun ComponentActivity.locateAuthHelperStore(authRequired: Boolean): Auth
 
 private fun Fragment.locateAuthHelperStore(authRequired: Boolean): AuthHelperStore {
     val viewingUserSelector = arguments?.getViewingUserSelector()
+
+    KaikenScopingTestUtils.getAuthHelperStoreTestOverride(viewingUserSelector)
+        ?.let { override ->
+            return override
+        }
+
     val context = requireActivity()
     val scopedServicesProvider = context.locateScopedServicesProvider()
 


### PR DESCRIPTION
BuildConfig.DEBUG is hard coded to false when we release to Maven.  

If consumers use this, they won't be able to override for their tests as it in a release.  

I think this does give the option that a consumer also abuses this functionality at runtime and uses it in production, but we'd need to refactor some code and extract things into another `scoping-test-util` module or similar. 