### PR TITLE
Update to new Sonatype host

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,14 @@ subprojects { Project project ->
     }
 }
 
+allprojects {
+    plugins.withId("com.vanniktech.maven.publish") {
+        mavenPublish {
+            sonatypeHost = "S01"
+        }
+    }
+}
+
 tasks.register("printVersionName") {
     doLast {
         println VERSION_NAME


### PR DESCRIPTION
Following steps in https://github.com/vanniktech/gradle-maven-publish-plugin#where-to-upload-to for pointing to the new host.