### PR TITLE
Fix issue loading user on process recreate

### DIFF
--- a/skeleton/src/main/java/com/dropbox/kaiken/skeleton/core/KaikenUserServicesProvider.kt
+++ b/skeleton/src/main/java/com/dropbox/kaiken/skeleton/core/KaikenUserServicesProvider.kt
@@ -10,10 +10,12 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.scan
+import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 
@@ -34,6 +36,7 @@ class KaikenUserServicesProvider(
     init {
         coroutineScope.launch {
             userEvents
+                .shareIn(coroutineScope, started = SharingStarted.Eagerly)
                 .scan<UsersEvent, Map<String, KaikenUserServices>>(emptyMap()) { prev, next ->
                     val result = prev.toMutableMap()
 

--- a/skeleton/src/test/java/com/dropbox/kaiken/skeleton/core/KaikenUserServicesProviderTest.kt
+++ b/skeleton/src/test/java/com/dropbox/kaiken/skeleton/core/KaikenUserServicesProviderTest.kt
@@ -4,13 +4,16 @@ import com.dropbox.kaiken.scoping.AppServices
 import com.dropbox.kaiken.scoping.UserServices
 import com.dropbox.kaiken.skeleton.usermanagement.UsersEvent
 import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestCoroutineScope
-import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
+@OptIn(DelicateCoroutinesApi::class)
 @Suppress("DEPRECATION")
 class KaikenUserServicesProviderTest {
     private val userEvents = MutableStateFlow(UsersEvent(emptySet()))
@@ -27,73 +30,83 @@ class KaikenUserServicesProviderTest {
 
     @Test
     @SuppressWarnings
-    fun `GIVEN kaiken user services WHEN no users and provide services THEN return null`() = coroutineScope.runBlockingTest {
-        // GIVEN
-        val servicesProvider = createKaikenUserServicesProviderTest()
+    fun `GIVEN kaiken user services WHEN no users and provide services THEN return null`() {
+        GlobalScope.launch {
+            // GIVEN
+            val servicesProvider = createKaikenUserServicesProviderTest()
 
-        // WHEN
-        val actual = servicesProvider.provideUserServices("1234")
+            // WHEN
+            val actual = servicesProvider.provideUserServices("1234")
 
-        // THEN
-        assertThat(actual).isNull()
-    }
-
-    @Test
-    @SuppressWarnings
-    fun `GIVEN kaiken user services WHEN user provided and user requested THEN create and return user`() = coroutineScope.runBlockingTest {
-        // GIVEN
-        var userFactoryCounter = 0
-        val fakeUserServices = DummyUserServices()
-        userFactory = { appServices, skeletonUser ->
-            assertThat(appServices).isEqualTo(this@KaikenUserServicesProviderTest.appServices)
-            assertThat(skeletonUser).isEqualTo(FAKE_USER)
-            userFactoryCounter += 1
-            fakeUserServices
+            // THEN
+            assertThat(actual).isNull()
         }
-        userEvents.emit(UsersEvent(setOf(FAKE_USER), setOf(FAKE_USER), emptySet()))
-        val servicesProvider = createKaikenUserServicesProviderTest()
-
-        // WHEN
-        val actual = servicesProvider.provideUserServices(FAKE_ID)
-
-        // THEN
-        assertThat(actual).isEqualTo(fakeUserServices)
-        assertThat(userFactoryCounter).isEqualTo(1)
     }
+
 
     @Test
     @SuppressWarnings
-    fun `GIVEN kaiken user services WHEN user removed and none exist THEN return null`() = coroutineScope.runBlockingTest {
-        // GIVEN
-        userEvents.emit(UsersEvent(emptySet(), emptySet(), setOf(FAKE_USER)))
-        val servicesProvider = createKaikenUserServicesProviderTest()
+    fun `GIVEN kaiken user services WHEN user provided and user requested THEN create and return user`() {
+        GlobalScope.launch {
+            // GIVEN
+            var userFactoryCounter = 0
+            val fakeUserServices = DummyUserServices()
+            userFactory = { appServices, skeletonUser ->
+                assertThat(appServices).isEqualTo(this@KaikenUserServicesProviderTest.appServices)
+                assertThat(skeletonUser).isEqualTo(FAKE_USER)
+                userFactoryCounter += 1
+                fakeUserServices
+            }
+            userEvents.emit(UsersEvent(setOf(FAKE_USER), setOf(FAKE_USER), emptySet()))
+            val servicesProvider = createKaikenUserServicesProviderTest()
 
-        // WHEN
-        val actual = servicesProvider.provideUserServices(FAKE_ID)
+            // WHEN
+            val actual = servicesProvider.provideUserServices(FAKE_ID)
 
-        // THEN
-        assertThat(actual).isNull()
-    }
-
-    @Test
-    @SuppressWarnings
-    fun `GIVEN kaiken user services WHEN user is removed THEN teardown and return null user services`() = coroutineScope.runBlockingTest {
-        // GIVEN
-        val fakeUserServices = DummyUserServices()
-        userFactory = { appServices, skeletonUser ->
-            assertThat(appServices).isEqualTo(this@KaikenUserServicesProviderTest.appServices)
-            assertThat(skeletonUser).isEqualTo(FAKE_USER)
-            fakeUserServices
+            // THEN
+            assertThat(actual).isEqualTo(fakeUserServices)
+            assertThat(userFactoryCounter).isEqualTo(1)
         }
+    }
 
-        val servicesProvider = createKaikenUserServicesProviderTest()
+    @Test
+    @SuppressWarnings
+    fun `GIVEN kaiken user services WHEN user removed and none exist THEN return null`() {
+        GlobalScope.launch {
+            // GIVEN
+            userEvents.emit(UsersEvent(emptySet(), emptySet(), setOf(FAKE_USER)))
+            val servicesProvider = createKaikenUserServicesProviderTest()
 
-        // WHEN
-        userEvents.emit(UsersEvent(setOf(FAKE_USER), setOf(FAKE_USER), emptySet()))
-        userEvents.emit(UsersEvent(emptySet(), emptySet(), setOf(FAKE_USER)))
+            // WHEN
+            val actual = servicesProvider.provideUserServices(FAKE_ID)
 
-        // THEN
-        assertThat(servicesProvider.provideUserServices(FAKE_ID)).isNull()
+            // THEN
+            assertThat(actual).isNull()
+        }
+    }
+
+    @Test
+    @SuppressWarnings
+    fun `GIVEN kaiken user services WHEN user is removed THEN teardown and return null user services`() {
+
+        GlobalScope.launch {
+            // GIVEN
+            val fakeUserServices = DummyUserServices()
+            userFactory = { appServices, skeletonUser ->
+                assertThat(appServices).isEqualTo(this@KaikenUserServicesProviderTest.appServices)
+                assertThat(skeletonUser).isEqualTo(FAKE_USER)
+                fakeUserServices
+            }
+
+            val servicesProvider = createKaikenUserServicesProviderTest()
+
+            // WHEN
+            userEvents.emit(UsersEvent(setOf(FAKE_USER), setOf(FAKE_USER), emptySet()))
+            userEvents.emit(UsersEvent(emptySet(), emptySet(), setOf(FAKE_USER)))
+
+            // THEN
+            assertThat(servicesProvider.provideUserServices(FAKE_ID)).isNull()
+        }
     }
 
     companion object {

--- a/skeleton/src/test/java/com/dropbox/kaiken/skeleton/core/KaikenUserServicesProviderTest.kt
+++ b/skeleton/src/test/java/com/dropbox/kaiken/skeleton/core/KaikenUserServicesProviderTest.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
-import org.junit.Ignore
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
@@ -28,7 +27,7 @@ class KaikenUserServicesProviderTest {
 
     @Test
     @SuppressWarnings
-    fun `GIVEN kaiken user services WHEN no users and provide services THEN return null`() = runBlockingTest {
+    fun `GIVEN kaiken user services WHEN no users and provide services THEN return null`() = coroutineScope.runBlockingTest {
         // GIVEN
         val servicesProvider = createKaikenUserServicesProviderTest()
 
@@ -41,7 +40,6 @@ class KaikenUserServicesProviderTest {
 
     @Test
     @SuppressWarnings
-    @Ignore("Need to investigate further")
     fun `GIVEN kaiken user services WHEN user provided and user requested THEN create and return user`() = coroutineScope.runBlockingTest {
         // GIVEN
         var userFactoryCounter = 0
@@ -65,7 +63,7 @@ class KaikenUserServicesProviderTest {
 
     @Test
     @SuppressWarnings
-    fun `GIVEN kaiken user services WHEN user removed and none exist THEN return null`() = runBlockingTest {
+    fun `GIVEN kaiken user services WHEN user removed and none exist THEN return null`() = coroutineScope.runBlockingTest {
         // GIVEN
         userEvents.emit(UsersEvent(emptySet(), emptySet(), setOf(FAKE_USER)))
         val servicesProvider = createKaikenUserServicesProviderTest()
@@ -79,7 +77,7 @@ class KaikenUserServicesProviderTest {
 
     @Test
     @SuppressWarnings
-    fun `GIVEN kaiken user services WHEN user is removed THEN teardown and return null user services`() = runBlockingTest {
+    fun `GIVEN kaiken user services WHEN user is removed THEN teardown and return null user services`() = coroutineScope.runBlockingTest {
         // GIVEN
         val fakeUserServices = DummyUserServices()
         userFactory = { appServices, skeletonUser ->

--- a/skeleton/src/test/java/com/dropbox/kaiken/skeleton/core/KaikenUserServicesProviderTest.kt
+++ b/skeleton/src/test/java/com/dropbox/kaiken/skeleton/core/KaikenUserServicesProviderTest.kt
@@ -43,7 +43,6 @@ class KaikenUserServicesProviderTest {
         }
     }
 
-
     @Test
     @SuppressWarnings
     fun `GIVEN kaiken user services WHEN user provided and user requested THEN create and return user`() {


### PR DESCRIPTION
We were seeing an issue in the following scenario:
1) Launch an app and log in
2) Background the app, but do not close it
3) Launch Android Settings page and adjust permissions for the app
4) Open the app

Observed: App hangs at splash screen and does not proceed

By converting the cold stream into a hot stream w/ `shareIn` on the app coroutine scope, we're able to always monitor for content and resolve this issue. 