### PR TITLE
Bind SkeletonUser instead of UserId with Anvil Components

### DIFF
--- a/sample/sample-with-di/app/src/main/java/com/dropbox/kaiken/sample/advancedsample/app/AdvancedKaikenSampleApplication.kt
+++ b/sample/sample-with-di/app/src/main/java/com/dropbox/kaiken/sample/advancedsample/app/AdvancedKaikenSampleApplication.kt
@@ -6,6 +6,7 @@ import com.dropbox.common.inject.SkeletonScope
 import com.dropbox.common.inject.UserScope
 import com.dropbox.kaiken.sample.advancedsample.helloworldfeature.UserProfile
 import com.dropbox.kaiken.skeleton.core.SkeletonOwnerApplication
+import com.dropbox.kaiken.skeleton.core.SkeletonUser
 import com.dropbox.kaiken.skeleton.dagger.SdkSpec
 import com.dropbox.kaiken.skeleton.scoping.SingleIn
 import com.dropbox.kaiken.skeleton.scoping.cast
@@ -37,7 +38,7 @@ interface ApplicationInjector {
 class UserModule {
     @Provides
     @SingleIn(UserScope::class)
-    fun provideUserProfile(userId: Int) = UserProfile(userId.toString(), userId.toString())
+    fun provideUserProfile(user: SkeletonUser) = UserProfile(user.userId, user.userId)
 }
 
 @ContributesTo(SkeletonScope::class)

--- a/skeleton-components/api/skeleton-components.api
+++ b/skeleton-components/api/skeleton-components.api
@@ -1,3 +1,8 @@
+public final class anvil/hint/binding/com/dropbox/kaiken/skeleton/core/Com_dropbox_kaiken_skeleton_core_KaikenConfigKt {
+	public static final fun getCom_dropbox_kaiken_skeleton_core_KaikenConfig_reference ()Lkotlin/reflect/KClass;
+	public static final fun getCom_dropbox_kaiken_skeleton_core_KaikenConfig_scope ()Lkotlin/reflect/KClass;
+}
+
 public final class anvil/hint/merge/com/dropbox/kaiken/skeleton/components/scoping/Com_dropbox_kaiken_skeleton_components_scoping_AppComponent_AppParentComponentKt {
 	public static final fun getCom_dropbox_kaiken_skeleton_components_scoping_AppComponent_AppParentComponent_reference ()Lkotlin/reflect/KClass;
 	public static final fun getCom_dropbox_kaiken_skeleton_components_scoping_AppComponent_AppParentComponent_scope ()Lkotlin/reflect/KClass;
@@ -26,11 +31,6 @@ public final class anvil/hint/merge/com/dropbox/kaiken/skeleton/components/scopi
 public final class anvil/hint/merge/com/dropbox/kaiken/skeleton/components/scoping/Com_dropbox_kaiken_skeleton_components_scoping_UserParentComponentKt {
 	public static final fun getCom_dropbox_kaiken_skeleton_components_scoping_UserParentComponent_reference ()Lkotlin/reflect/KClass;
 	public static final fun getCom_dropbox_kaiken_skeleton_components_scoping_UserParentComponent_scope ()Lkotlin/reflect/KClass;
-}
-
-public final class anvil/hint/merge/com/dropbox/kaiken/skeleton/core/Com_dropbox_kaiken_skeleton_core_KaikenConfigBindingKt {
-	public static final fun getCom_dropbox_kaiken_skeleton_core_KaikenConfigBinding_reference ()Lkotlin/reflect/KClass;
-	public static final fun getCom_dropbox_kaiken_skeleton_core_KaikenConfigBinding_scope ()Lkotlin/reflect/KClass;
 }
 
 public final class anvil/hint/subcomponent/com/dropbox/kaiken/skeleton/components/scoping/Com_dropbox_kaiken_skeleton_components_scoping_AppComponentKt {
@@ -134,7 +134,7 @@ public abstract interface class com/dropbox/kaiken/skeleton/components/scoping/U
 }
 
 public abstract interface class com/dropbox/kaiken/skeleton/components/scoping/UserComponent$Factory {
-	public abstract fun userComponent (I)Lcom/dropbox/kaiken/skeleton/components/scoping/UserComponent;
+	public abstract fun userComponent (Lcom/dropbox/kaiken/skeleton/core/SkeletonUser;)Lcom/dropbox/kaiken/skeleton/components/scoping/UserComponent;
 }
 
 public abstract interface class com/dropbox/kaiken/skeleton/components/scoping/UserParentComponent {
@@ -144,11 +144,6 @@ public abstract interface class com/dropbox/kaiken/skeleton/components/scoping/U
 public final class com/dropbox/kaiken/skeleton/core/KaikenConfig : com/dropbox/kaiken/skeleton/core/SkeletonConfig {
 	public fun <init> ()V
 	public fun getScopedServicesFactory ()Lcom/dropbox/kaiken/skeleton/core/AppSpecificScopedServicesFactory;
-}
-
-public abstract class com/dropbox/kaiken/skeleton/core/KaikenConfigBinding {
-	public fun <init> ()V
-	public abstract fun bindKaikenConfigBinding (Lcom/dropbox/kaiken/skeleton/core/KaikenConfig;)Lcom/dropbox/kaiken/skeleton/core/SkeletonConfig;
 }
 
 public final class com/dropbox/kaiken/skeleton/core/KaikenConfig_Factory : dagger/internal/Factory {

--- a/skeleton-components/src/main/java/com/dropbox/kaiken/skeleton/components/scoping/Components.kt
+++ b/skeleton-components/src/main/java/com/dropbox/kaiken/skeleton/components/scoping/Components.kt
@@ -20,6 +20,7 @@ import com.dropbox.kaiken.scoping.AuthOptionalFragment
 import com.dropbox.kaiken.scoping.AuthRequiredFragment
 import com.dropbox.kaiken.scoping.DependencyProviderResolver
 import com.dropbox.kaiken.scoping.UserServices
+import com.dropbox.kaiken.skeleton.core.SkeletonUser
 import com.dropbox.kaiken.skeleton.scoping.SingleIn
 import com.squareup.anvil.annotations.ContributesSubcomponent
 import com.squareup.anvil.annotations.ContributesTo
@@ -51,7 +52,7 @@ interface UserComponent : UserServices {
     @ContributesSubcomponent.Factory
     interface Factory {
         fun userComponent(
-            @BindsInstance userId: Int
+            @BindsInstance user: SkeletonUser
         ): UserComponent
     }
 }

--- a/skeleton-components/src/main/java/com/dropbox/kaiken/skeleton/core/KaikenConfig.kt
+++ b/skeleton-components/src/main/java/com/dropbox/kaiken/skeleton/core/KaikenConfig.kt
@@ -8,11 +8,11 @@ import com.dropbox.kaiken.skeleton.components.scoping.UserParentComponent
 import com.dropbox.kaiken.skeleton.dagger.SdkSpec
 import com.dropbox.kaiken.skeleton.scoping.SingleIn
 import com.dropbox.kaiken.skeleton.scoping.cast
-import com.squareup.anvil.annotations.ContributesTo
-import dagger.Binds
-import dagger.Module
+import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 
+@ContributesBinding(SkeletonScope::class)
+@SingleIn(SkeletonScope::class)
 class KaikenConfig @Inject constructor() : SkeletonConfig {
     override val scopedServicesFactory: AppSpecificScopedServicesFactory
         get() = object : AppSpecificScopedServicesFactory {
@@ -23,14 +23,6 @@ class KaikenConfig @Inject constructor() : SkeletonConfig {
                 appServices: AppServices,
                 user: SkeletonUser,
             ): UserComponent = appServices.cast<UserParentComponent>().createUserComponent()
-                .userComponent(userId = user.userId.toInt())
+                .userComponent(user)
         }
-}
-
-@ContributesTo(SkeletonScope::class)
-@Module
-abstract class KaikenConfigBinding {
-    @SingleIn(SkeletonScope::class)
-    @Binds
-    abstract fun bindKaikenConfigBinding(real: KaikenConfig): SkeletonConfig
 }

--- a/skeleton-components/src/test/java/com/dropbox/kaiken/skeleton/scoping/fugazi/FakeSkeletonConfig.kt
+++ b/skeleton-components/src/test/java/com/dropbox/kaiken/skeleton/scoping/fugazi/FakeSkeletonConfig.kt
@@ -6,17 +6,17 @@ import com.dropbox.kaiken.scoping.UserServices
 import com.dropbox.kaiken.skeleton.components.scoping.AppComponent
 import com.dropbox.kaiken.skeleton.components.scoping.UserParentComponent
 import com.dropbox.kaiken.skeleton.core.AppSpecificScopedServicesFactory
-import com.dropbox.kaiken.skeleton.core.KaikenConfigBinding
+import com.dropbox.kaiken.skeleton.core.KaikenConfig
 import com.dropbox.kaiken.skeleton.core.SkeletonConfig
 import com.dropbox.kaiken.skeleton.core.SkeletonUser
 import com.dropbox.kaiken.skeleton.dagger.SdkSpec
 import com.dropbox.kaiken.skeleton.scoping.SingleIn
 import com.dropbox.kaiken.skeleton.scoping.cast
-import com.squareup.anvil.annotations.ContributesTo
-import dagger.Binds
-import dagger.Module
+import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 
+@ContributesBinding(SkeletonScope::class, replaces = [KaikenConfig::class])
+@SingleIn(SkeletonScope::class)
 class FakeSkeletonConfig @Inject constructor() : SkeletonConfig {
     override val scopedServicesFactory: AppSpecificScopedServicesFactory
         get() = object : AppSpecificScopedServicesFactory {
@@ -32,14 +32,6 @@ class FakeSkeletonConfig @Inject constructor() : SkeletonConfig {
                 appServices
                     .cast<UserParentComponent>()
                     .createUserComponent()
-                    .userComponent(user.userId.toInt())
+                    .userComponent(user)
         }
-}
-
-@ContributesTo(SkeletonScope::class, replaces = [KaikenConfigBinding::class])
-@Module
-abstract class FakeSkeletonConfigBinding {
-    @SingleIn(SkeletonScope::class)
-    @Binds
-    abstract fun bindSkeletonConfig(real: FakeSkeletonConfig): SkeletonConfig
 }


### PR DESCRIPTION
Binding the userId worked for sample apps, but we will need the SkeletonUser for production apps 