### PR TITLE
Fix generator to allow scopes outside classpath and multiple bindings

### DIFF
--- a/processor/src/main/java/com/dropbox/kaiken/processor/InjectableActivityWriter.kt
+++ b/processor/src/main/java/com/dropbox/kaiken/processor/InjectableActivityWriter.kt
@@ -3,9 +3,13 @@ package com.dropbox.kaiken.processor
 import com.dropbox.kaiken.Injector
 import com.dropbox.kaiken.processor.internal.GENERATED_BY_TOP_COMMENT
 import com.dropbox.kaiken.processor.internal.generateContributesInjector
+import com.squareup.anvil.annotations.ContributesTo
+import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.MemberName
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.typeNameOf
@@ -80,8 +84,7 @@ private fun generateInjectInterfaceForActivity(
 internal fun generateActivityFileSpec(
     pack: String,
     interfaceName: String,
-    typeName: TypeName,
-    authAwarenessScope: KClass<out Any>?
+    typeName: TypeName
 ): FileSpec {
     val extensionFunctionSpec = generateInjectExtensionFunctionForActivity(
         interfaceName, typeName
@@ -89,18 +92,10 @@ internal fun generateActivityFileSpec(
     val interfaceTypeSpec = generateInjectInterfaceForActivity(
         interfaceName, typeName
     )
-    val contributesInjectorTypeSpec = generateContributesInjector(
-        pack, interfaceName, authAwarenessScope
-    )
     val fileBuilder = FileSpec.builder(pack, interfaceName)
 
     return fileBuilder.addComment(GENERATED_BY_TOP_COMMENT)
         .addFunction(extensionFunctionSpec)
         .addType(interfaceTypeSpec)
-        .apply {
-            if (contributesInjectorTypeSpec != null) {
-                addType(contributesInjectorTypeSpec)
-            }
-        }
         .build()
 }

--- a/processor/src/main/java/com/dropbox/kaiken/processor/InjectableActivityWriter.kt
+++ b/processor/src/main/java/com/dropbox/kaiken/processor/InjectableActivityWriter.kt
@@ -2,18 +2,12 @@ package com.dropbox.kaiken.processor
 
 import com.dropbox.kaiken.Injector
 import com.dropbox.kaiken.processor.internal.GENERATED_BY_TOP_COMMENT
-import com.dropbox.kaiken.processor.internal.generateContributesInjector
-import com.squareup.anvil.annotations.ContributesTo
-import com.squareup.kotlinpoet.AnnotationSpec
-import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
-import com.squareup.kotlinpoet.MemberName
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.typeNameOf
-import kotlin.reflect.KClass
 
 /**
  * Generates a `Injector` interface definition and an `inject` function for the given annotated

--- a/processor/src/main/java/com/dropbox/kaiken/processor/InjectableCodeGenerator.kt
+++ b/processor/src/main/java/com/dropbox/kaiken/processor/InjectableCodeGenerator.kt
@@ -2,7 +2,6 @@ package com.dropbox.kaiken.processor
 
 import com.dropbox.common.inject.AuthOptionalScope
 import com.dropbox.common.inject.AuthRequiredScope
-import com.dropbox.common.inject.UserScope
 import com.dropbox.kaiken.annotation.Injectable
 import com.dropbox.kaiken.processor.internal.GENERATED_BY_TOP_COMMENT
 import com.dropbox.kaiken.processor.internal.generateContributesInjector

--- a/processor/src/main/java/com/dropbox/kaiken/processor/InjectableFragmentWriter.kt
+++ b/processor/src/main/java/com/dropbox/kaiken/processor/InjectableFragmentWriter.kt
@@ -81,14 +81,10 @@ internal fun generateFragmentFileSpec(
     pack: String,
     interfaceName: String,
     fragmentType: TypeName,
-    authAwarenessScope: KClass<*>?,
     shouldGenerateAuthAww: Boolean,
 ): FileSpec {
     val extensionFunctionSpec = generateInjectExtensionFunction(interfaceName, fragmentType)
     val interfaceSpec = generateInjectInterfaceSpec(interfaceName, fragmentType)
-    val contributesInjectorTypeSpec = generateContributesInjector(
-        pack, interfaceName, authAwarenessScope
-    )
 
     val fileBuilder = FileSpec.builder(pack, interfaceName)
 
@@ -96,10 +92,5 @@ internal fun generateFragmentFileSpec(
         .addImport("com.dropbox.kaiken.runtime", "findInjector")
         .addFunction(extensionFunctionSpec)
         .addType(interfaceSpec)
-        .apply {
-            if (contributesInjectorTypeSpec != null) {
-                addType(contributesInjectorTypeSpec)
-            }
-        }
         .build()
 }

--- a/processor/src/main/java/com/dropbox/kaiken/processor/InjectableFragmentWriter.kt
+++ b/processor/src/main/java/com/dropbox/kaiken/processor/InjectableFragmentWriter.kt
@@ -2,14 +2,12 @@ package com.dropbox.kaiken.processor
 
 import com.dropbox.kaiken.Injector
 import com.dropbox.kaiken.processor.internal.GENERATED_BY_TOP_COMMENT
-import com.dropbox.kaiken.processor.internal.generateContributesInjector
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.typeNameOf
-import kotlin.reflect.KClass
 
 /**
  * Generates a `Injector` interface definition and an `inject` function for the given annotated

--- a/processor/src/main/java/com/dropbox/kaiken/processor/internal/InjectableSharedWriter.kt
+++ b/processor/src/main/java/com/dropbox/kaiken/processor/internal/InjectableSharedWriter.kt
@@ -16,7 +16,7 @@ internal fun generateContributesInjector(
     if (authAwarenessScope == null) {
         return null
     }
-    val interfaceBuilder = TypeSpec.interfaceBuilder("${interfaceName}ScopeContributor")
+    val interfaceBuilder = TypeSpec.interfaceBuilder("${interfaceName}${authAwarenessScope.simpleName}Contributor")
     val contributionAnnotationScope = MemberName("com.dropbox.common.inject", "${authAwarenessScope.simpleName}")
     return interfaceBuilder
         .addAnnotation(

--- a/processor/src/main/java/com/dropbox/kaiken/processor/internal/InjectableSharedWriter.kt
+++ b/processor/src/main/java/com/dropbox/kaiken/processor/internal/InjectableSharedWriter.kt
@@ -6,18 +6,15 @@ import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.MemberName
 import com.squareup.kotlinpoet.TypeSpec
-import kotlin.reflect.KClass
+import org.jetbrains.kotlin.name.FqName
 
 internal fun generateContributesInjector(
     pack: String,
     interfaceName: String,
-    authAwarenessScope: KClass<out Any>?
-): TypeSpec? {
-    if (authAwarenessScope == null) {
-        return null
-    }
-    val interfaceBuilder = TypeSpec.interfaceBuilder("${interfaceName}${authAwarenessScope.simpleName}Contributor")
-    val contributionAnnotationScope = MemberName("com.dropbox.common.inject", "${authAwarenessScope.simpleName}")
+    authAwarenessScope: FqName
+): TypeSpec {
+    val interfaceBuilder = TypeSpec.interfaceBuilder("${interfaceName}${authAwarenessScope.shortName().asString()}Contributor")
+    val contributionAnnotationScope = MemberName(authAwarenessScope.parent().asString(), authAwarenessScope.shortName().asString())
     return interfaceBuilder
         .addAnnotation(
             AnnotationSpec.builder(ContributesTo::class)

--- a/scoping/build.gradle
+++ b/scoping/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     implementation deps.dagger2
 
     api project(":annotations")
+    implementation project(path: ':runtime')
 
     debugImplementation deps.appcompat
 

--- a/scoping/build.gradle
+++ b/scoping/build.gradle
@@ -12,7 +12,6 @@ dependencies {
     implementation deps.dagger2
 
     api project(":annotations")
-    implementation project(path: ':runtime')
 
     debugImplementation deps.appcompat
 


### PR DESCRIPTION
This PR fixes two issues

1. Previously, when using `Class.forName` in the generator, if the scope wasn't in the classpath the generator would fail. This meant you could not provide custom scopes and only use the ones built into kaiken
2. Anvil has an issue with multiple `@ContributesTo` bindings existing for the same class. This moves the generator to build out separate classes until we update to the latest version of Anvil (https://github.com/square/anvil/issues/236) which should now support this without the multiple class hack