### PR TITLE
Add UserProvider

### DIFF
--- a/scoping-navgraph/api/scoping-navgraph.api
+++ b/scoping-navgraph/api/scoping-navgraph.api
@@ -4,10 +4,12 @@ public final class com/dropbox/kaiken/scoping_navgraph/AuthAwareNavHostFragment 
 
 public final class com/dropbox/kaiken/scoping_navgraph/AuthOptionalNavHostFragment : androidx/navigation/fragment/NavHostFragment, com/dropbox/kaiken/scoping/AuthOptionalFragment {
 	public fun <init> ()V
+	public fun getUser ()Lcom/dropbox/kaiken/scoping/ViewingUserSelector;
 }
 
 public final class com/dropbox/kaiken/scoping_navgraph/AuthRequiredNavHostFragment : androidx/navigation/fragment/NavHostFragment, com/dropbox/kaiken/scoping/AuthRequiredFragment {
 	public fun <init> ()V
+	public fun getUser ()Lcom/dropbox/kaiken/scoping/ViewingUserSelector;
 }
 
 public final class com/dropbox/kaiken/scoping_navgraph/BuildConfig {

--- a/scoping/api/scoping.api
+++ b/scoping/api/scoping.api
@@ -53,13 +53,15 @@ public final class com/dropbox/kaiken/scoping/AuthAwareScopeOwnerFragment$Defaul
 	public static fun resolveDependencyProvider (Lcom/dropbox/kaiken/scoping/AuthAwareScopeOwnerFragment;)Ljava/lang/Object;
 }
 
-public abstract interface class com/dropbox/kaiken/scoping/AuthOptionalActivity : com/dropbox/kaiken/scoping/AuthAwareScopeOwnerActivity, com/dropbox/kaiken/scoping/DependencyProviderResolver {
+public abstract interface class com/dropbox/kaiken/scoping/AuthOptionalActivity : com/dropbox/kaiken/scoping/AuthAwareScopeOwnerActivity, com/dropbox/kaiken/scoping/DependencyProviderResolver, com/dropbox/kaiken/scoping/UserProvider {
 	public fun getAuthRequired ()Z
+	public fun getUser ()Lcom/dropbox/kaiken/scoping/ViewingUserSelector;
 }
 
 public final class com/dropbox/kaiken/scoping/AuthOptionalActivity$DefaultImpls {
 	public static fun finishIfInvalidAuth (Lcom/dropbox/kaiken/scoping/AuthOptionalActivity;)Z
 	public static fun getAuthRequired (Lcom/dropbox/kaiken/scoping/AuthOptionalActivity;)Z
+	public static fun getUser (Lcom/dropbox/kaiken/scoping/AuthOptionalActivity;)Lcom/dropbox/kaiken/scoping/ViewingUserSelector;
 	public static fun getViewingUserSelector (Lcom/dropbox/kaiken/scoping/AuthOptionalActivity;)Lcom/dropbox/kaiken/scoping/ViewingUserSelector;
 	public static fun resolveDependencyProvider (Lcom/dropbox/kaiken/scoping/AuthOptionalActivity;)Ljava/lang/Object;
 }
@@ -73,17 +75,18 @@ public final class com/dropbox/kaiken/scoping/AuthOptionalBroadcastReceiver$Defa
 	public static fun onReceiveResolveDependencyProvider (Lcom/dropbox/kaiken/scoping/AuthOptionalBroadcastReceiver;Landroid/content/Context;Landroid/content/Intent;)Ljava/lang/Object;
 }
 
-public abstract interface class com/dropbox/kaiken/scoping/AuthOptionalFragment : com/dropbox/kaiken/scoping/AuthAwareScopeOwnerFragment {
+public abstract interface class com/dropbox/kaiken/scoping/AuthOptionalFragment : com/dropbox/kaiken/scoping/AuthAwareScopeOwnerFragment, com/dropbox/kaiken/scoping/UserProvider {
 	public fun getAuthRequired ()Z
 }
 
 public final class com/dropbox/kaiken/scoping/AuthOptionalFragment$DefaultImpls {
 	public static fun finishIfInvalidAuth (Lcom/dropbox/kaiken/scoping/AuthOptionalFragment;)Z
 	public static fun getAuthRequired (Lcom/dropbox/kaiken/scoping/AuthOptionalFragment;)Z
+	public static fun getUser (Lcom/dropbox/kaiken/scoping/AuthOptionalFragment;)Lcom/dropbox/kaiken/scoping/ViewingUserSelector;
 	public static fun resolveDependencyProvider (Lcom/dropbox/kaiken/scoping/AuthOptionalFragment;)Ljava/lang/Object;
 }
 
-public abstract interface class com/dropbox/kaiken/scoping/AuthRequiredActivity : com/dropbox/kaiken/scoping/AuthAwareScopeOwnerActivity, com/dropbox/kaiken/scoping/DependencyProviderResolver {
+public abstract interface class com/dropbox/kaiken/scoping/AuthRequiredActivity : com/dropbox/kaiken/scoping/AuthAwareScopeOwnerActivity, com/dropbox/kaiken/scoping/DependencyProviderResolver, com/dropbox/kaiken/scoping/RequiredUserProvider {
 	public fun getAuthRequired ()Z
 	public fun requireViewingUserSelector ()Lcom/dropbox/kaiken/scoping/ViewingUserSelector;
 }
@@ -91,6 +94,7 @@ public abstract interface class com/dropbox/kaiken/scoping/AuthRequiredActivity 
 public final class com/dropbox/kaiken/scoping/AuthRequiredActivity$DefaultImpls {
 	public static fun finishIfInvalidAuth (Lcom/dropbox/kaiken/scoping/AuthRequiredActivity;)Z
 	public static fun getAuthRequired (Lcom/dropbox/kaiken/scoping/AuthRequiredActivity;)Z
+	public static fun getUser (Lcom/dropbox/kaiken/scoping/AuthRequiredActivity;)Lcom/dropbox/kaiken/scoping/ViewingUserSelector;
 	public static fun getViewingUserSelector (Lcom/dropbox/kaiken/scoping/AuthRequiredActivity;)Lcom/dropbox/kaiken/scoping/ViewingUserSelector;
 	public static fun requireViewingUserSelector (Lcom/dropbox/kaiken/scoping/AuthRequiredActivity;)Lcom/dropbox/kaiken/scoping/ViewingUserSelector;
 	public static fun resolveDependencyProvider (Lcom/dropbox/kaiken/scoping/AuthRequiredActivity;)Ljava/lang/Object;
@@ -105,13 +109,14 @@ public final class com/dropbox/kaiken/scoping/AuthRequiredBroadcastReceiver$Defa
 	public static fun onReceiveResolveDependencyProvider (Lcom/dropbox/kaiken/scoping/AuthRequiredBroadcastReceiver;Landroid/content/Context;Landroid/content/Intent;)Ljava/lang/Object;
 }
 
-public abstract interface class com/dropbox/kaiken/scoping/AuthRequiredFragment : com/dropbox/kaiken/scoping/AuthAwareScopeOwnerFragment {
+public abstract interface class com/dropbox/kaiken/scoping/AuthRequiredFragment : com/dropbox/kaiken/scoping/AuthAwareScopeOwnerFragment, com/dropbox/kaiken/scoping/RequiredUserProvider {
 	public fun getAuthRequired ()Z
 }
 
 public final class com/dropbox/kaiken/scoping/AuthRequiredFragment$DefaultImpls {
 	public static fun finishIfInvalidAuth (Lcom/dropbox/kaiken/scoping/AuthRequiredFragment;)Z
 	public static fun getAuthRequired (Lcom/dropbox/kaiken/scoping/AuthRequiredFragment;)Z
+	public static fun getUser (Lcom/dropbox/kaiken/scoping/AuthRequiredFragment;)Lcom/dropbox/kaiken/scoping/ViewingUserSelector;
 	public static fun resolveDependencyProvider (Lcom/dropbox/kaiken/scoping/AuthRequiredFragment;)Ljava/lang/Object;
 }
 
@@ -120,11 +125,27 @@ public abstract interface class com/dropbox/kaiken/scoping/DependencyProviderRes
 	public abstract fun resolveDependencyProvider ()Ljava/lang/Object;
 }
 
+public abstract interface class com/dropbox/kaiken/scoping/RequiredUserProvider : com/dropbox/kaiken/scoping/UserProvider {
+	public abstract fun getUser ()Lcom/dropbox/kaiken/scoping/ViewingUserSelector;
+}
+
+public final class com/dropbox/kaiken/scoping/RequiredUserProvider$DefaultImpls {
+	public static fun getUser (Lcom/dropbox/kaiken/scoping/RequiredUserProvider;)Lcom/dropbox/kaiken/scoping/ViewingUserSelector;
+}
+
 public abstract interface class com/dropbox/kaiken/scoping/ScopedServicesProvider : com/dropbox/kaiken/scoping/AppServicesProvider, com/dropbox/kaiken/scoping/UserServicesProvider {
 }
 
 public final class com/dropbox/kaiken/scoping/ScopedServicesProvider$DefaultImpls {
 	public static fun provideUserServicesOf (Lcom/dropbox/kaiken/scoping/ScopedServicesProvider;Lcom/dropbox/kaiken/scoping/ViewingUserSelector;)Lcom/dropbox/kaiken/scoping/UserServices;
+}
+
+public abstract interface class com/dropbox/kaiken/scoping/UserProvider {
+	public abstract fun getUser ()Lcom/dropbox/kaiken/scoping/ViewingUserSelector;
+}
+
+public final class com/dropbox/kaiken/scoping/UserProvider$DefaultImpls {
+	public static fun getUser (Lcom/dropbox/kaiken/scoping/UserProvider;)Lcom/dropbox/kaiken/scoping/ViewingUserSelector;
 }
 
 public abstract interface class com/dropbox/kaiken/scoping/UserServices {

--- a/scoping/src/main/java/com/dropbox/kaiken/scoping/AuthOptionalActivity.kt
+++ b/scoping/src/main/java/com/dropbox/kaiken/scoping/AuthOptionalActivity.kt
@@ -3,8 +3,12 @@ package com.dropbox.kaiken.scoping
 /**
  * An activity that does not require a user to be logged in.
  */
-interface AuthOptionalActivity : AuthAwareScopeOwnerActivity, DependencyProviderResolver {
+interface AuthOptionalActivity : AuthAwareScopeOwnerActivity, DependencyProviderResolver, UserProvider {
     @JvmDefault
     override val authRequired: Boolean
         get() = false
+
+    @JvmDefault
+    override val user: ViewingUserSelector?
+        get() = super.user
 }

--- a/scoping/src/main/java/com/dropbox/kaiken/scoping/AuthOptionalFragment.kt
+++ b/scoping/src/main/java/com/dropbox/kaiken/scoping/AuthOptionalFragment.kt
@@ -6,7 +6,7 @@ package com.dropbox.kaiken.scoping
  * Avoid using this class. This should only be used when it's not possible for the parent activity
  * to be an [AuthAwareScopeOwnerActivity].
  */
-interface AuthOptionalFragment : AuthAwareScopeOwnerFragment {
+interface AuthOptionalFragment : AuthAwareScopeOwnerFragment, UserProvider {
     @JvmDefault
     override val authRequired: Boolean
         get() = false

--- a/scoping/src/main/java/com/dropbox/kaiken/scoping/AuthRequiredActivity.kt
+++ b/scoping/src/main/java/com/dropbox/kaiken/scoping/AuthRequiredActivity.kt
@@ -3,7 +3,7 @@ package com.dropbox.kaiken.scoping
 /**
  * An activity that requires a user to be logged in.
  */
-interface AuthRequiredActivity : AuthAwareScopeOwnerActivity, DependencyProviderResolver {
+interface AuthRequiredActivity : AuthAwareScopeOwnerActivity, DependencyProviderResolver, RequiredUserProvider {
     @JvmDefault
     override val authRequired: Boolean
         get() = true

--- a/scoping/src/main/java/com/dropbox/kaiken/scoping/AuthRequiredFragment.kt
+++ b/scoping/src/main/java/com/dropbox/kaiken/scoping/AuthRequiredFragment.kt
@@ -6,7 +6,7 @@ package com.dropbox.kaiken.scoping
  * Avoid using this class. This should only be used when it's not possible for the parent activity
  * to be an [AuthAwareScopeOwnerActivity].
  */
-interface AuthRequiredFragment : AuthAwareScopeOwnerFragment {
+interface AuthRequiredFragment : AuthAwareScopeOwnerFragment, RequiredUserProvider {
     @JvmDefault
     override val authRequired: Boolean
         get() = true

--- a/scoping/src/main/java/com/dropbox/kaiken/scoping/UserProvider.kt
+++ b/scoping/src/main/java/com/dropbox/kaiken/scoping/UserProvider.kt
@@ -1,0 +1,18 @@
+package com.dropbox.kaiken.scoping
+
+import android.app.Activity
+import androidx.fragment.app.Fragment
+
+interface UserProvider {
+    val user: ViewingUserSelector?
+        get() = when (this) {
+            is Fragment -> arguments?.getViewingUserSelector()
+            is Activity -> intent?.extras?.getViewingUserSelector()
+            else -> null
+        }
+}
+
+interface RequiredUserProvider : UserProvider {
+    override val user: ViewingUserSelector
+        get() = super.user ?: error("Must have user")
+}

--- a/skeleton-components/api/skeleton-components.api
+++ b/skeleton-components/api/skeleton-components.api
@@ -77,21 +77,11 @@ public abstract interface class com/dropbox/kaiken/skeleton/components/scoping/A
 	public abstract fun appComponent ()Lcom/dropbox/kaiken/skeleton/components/scoping/AppComponent;
 }
 
-public abstract class com/dropbox/kaiken/skeleton/components/scoping/AuthAwareInjectorHolder : androidx/fragment/app/Fragment, com/dropbox/kaiken/runtime/InjectorHolder, com/dropbox/kaiken/scoping/AuthAwareFragment {
-	public fun <init> ()V
-	public fun locateInjector ()Lcom/dropbox/kaiken/Injector;
-}
-
 public abstract interface class com/dropbox/kaiken/skeleton/components/scoping/AuthOptionalComponent : com/dropbox/kaiken/Injector {
 }
 
 public abstract interface class com/dropbox/kaiken/skeleton/components/scoping/AuthOptionalComponent$ParentComponent {
 	public abstract fun createAuthOptionalComponent ()Lcom/dropbox/kaiken/skeleton/components/scoping/AuthOptionalComponent;
-}
-
-public abstract class com/dropbox/kaiken/skeleton/components/scoping/AuthOptionalInjectorHolder : androidx/fragment/app/Fragment, com/dropbox/kaiken/runtime/InjectorHolder, com/dropbox/kaiken/scoping/AuthOptionalFragment {
-	public fun <init> ()V
-	public fun locateInjector ()Lcom/dropbox/kaiken/Injector;
 }
 
 public abstract interface class com/dropbox/kaiken/skeleton/components/scoping/AuthOptionalScreenComponent : com/dropbox/kaiken/Injector {
@@ -108,11 +98,6 @@ public abstract interface class com/dropbox/kaiken/skeleton/components/scoping/A
 	public abstract fun createAuthRequiredComponent ()Lcom/dropbox/kaiken/skeleton/components/scoping/AuthRequiredComponent;
 }
 
-public abstract class com/dropbox/kaiken/skeleton/components/scoping/AuthRequiredInjectorHolder : androidx/fragment/app/Fragment, com/dropbox/kaiken/runtime/InjectorHolder, com/dropbox/kaiken/scoping/AuthRequiredFragment {
-	public fun <init> ()V
-	public fun locateInjector ()Lcom/dropbox/kaiken/Injector;
-}
-
 public abstract interface class com/dropbox/kaiken/skeleton/components/scoping/AuthRequiredScreenComponent : com/dropbox/kaiken/Injector {
 }
 
@@ -122,7 +107,7 @@ public abstract interface class com/dropbox/kaiken/skeleton/components/scoping/A
 
 public final class com/dropbox/kaiken/skeleton/components/scoping/ComponentsKt {
 	public static final synthetic fun authInjector (Lcom/dropbox/kaiken/scoping/DependencyProviderResolver;)Lcom/dropbox/kaiken/runtime/InjectorFactory;
-	public static final synthetic fun authOptionalInjectorFactory (Lcom/dropbox/kaiken/scoping/DependencyProviderResolver;)Lcom/dropbox/kaiken/runtime/InjectorFactory;
+	public static final synthetic fun authOptionalInjectorFactory (Lcom/dropbox/kaiken/scoping/UserProvider;)Lcom/dropbox/kaiken/runtime/InjectorFactory;
 }
 
 public final class com/dropbox/kaiken/skeleton/components/scoping/InjectorViewModelFactory : androidx/lifecycle/ViewModelProvider$Factory {

--- a/skeleton-components/src/main/java/com/dropbox/kaiken/skeleton/components/scoping/Components.kt
+++ b/skeleton-components/src/main/java/com/dropbox/kaiken/skeleton/components/scoping/Components.kt
@@ -1,6 +1,5 @@
 package com.dropbox.kaiken.skeleton.components.scoping
 
-import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.dropbox.common.inject.AppScope
@@ -12,12 +11,8 @@ import com.dropbox.common.inject.SkeletonScope
 import com.dropbox.common.inject.UserScope
 import com.dropbox.kaiken.Injector
 import com.dropbox.kaiken.runtime.InjectorFactory
-import com.dropbox.kaiken.runtime.InjectorHolder
 import com.dropbox.kaiken.runtime.InjectorViewModel
 import com.dropbox.kaiken.scoping.AppServices
-import com.dropbox.kaiken.scoping.AuthAwareFragment
-import com.dropbox.kaiken.scoping.AuthOptionalFragment
-import com.dropbox.kaiken.scoping.AuthRequiredFragment
 import com.dropbox.kaiken.scoping.DependencyProviderResolver
 import com.dropbox.kaiken.scoping.UserProvider
 import com.dropbox.kaiken.scoping.UserServices
@@ -122,14 +117,13 @@ interface AuthRequiredScreenComponent : Injector {
 inline fun <reified T : Injector, UserAndDependencyProvider> UserAndDependencyProvider.authOptionalInjectorFactory()
         where UserAndDependencyProvider : UserProvider,
               UserAndDependencyProvider : DependencyProviderResolver = if (user != null) {
-        authInjector()
-    } else {
-        InjectorFactory { (resolveDependencyProvider() as AuthOptionalComponent.ParentComponent).createAuthOptionalComponent() as T }
-    }
+    authInjector()
+} else {
+    InjectorFactory { (resolveDependencyProvider() as AuthOptionalComponent.ParentComponent).createAuthOptionalComponent() as T }
+}
 
 inline fun <reified T : Injector> DependencyProviderResolver.authInjector() =
     InjectorFactory { (resolveDependencyProvider() as AuthRequiredComponent.ParentComponent).createAuthRequiredComponent() as T }
-
 
 class InjectorViewModelFactory<InjectorType : Injector>(
     private val injectorFactory: InjectorFactory<InjectorType>

--- a/skeleton-components/src/main/java/com/dropbox/kaiken/skeleton/components/scoping/Components.kt
+++ b/skeleton-components/src/main/java/com/dropbox/kaiken/skeleton/components/scoping/Components.kt
@@ -19,6 +19,7 @@ import com.dropbox.kaiken.scoping.AuthAwareFragment
 import com.dropbox.kaiken.scoping.AuthOptionalFragment
 import com.dropbox.kaiken.scoping.AuthRequiredFragment
 import com.dropbox.kaiken.scoping.DependencyProviderResolver
+import com.dropbox.kaiken.scoping.UserProvider
 import com.dropbox.kaiken.scoping.UserServices
 import com.dropbox.kaiken.skeleton.core.SkeletonUser
 import com.dropbox.kaiken.skeleton.scoping.SingleIn
@@ -118,26 +119,17 @@ interface AuthRequiredScreenComponent : Injector {
     }
 }
 
-inline fun <reified T : Injector> DependencyProviderResolver.authOptionalInjectorFactory() =
-    InjectorFactory { (resolveDependencyProvider() as AuthOptionalComponent.ParentComponent).createAuthOptionalComponent() as T }
+inline fun <reified T : Injector, UserAndDependencyProvider> UserAndDependencyProvider.authOptionalInjectorFactory()
+        where UserAndDependencyProvider : UserProvider,
+              UserAndDependencyProvider : DependencyProviderResolver = if (user != null) {
+        authInjector()
+    } else {
+        InjectorFactory { (resolveDependencyProvider() as AuthOptionalComponent.ParentComponent).createAuthOptionalComponent() as T }
+    }
 
 inline fun <reified T : Injector> DependencyProviderResolver.authInjector() =
     InjectorFactory { (resolveDependencyProvider() as AuthRequiredComponent.ParentComponent).createAuthRequiredComponent() as T }
 
-abstract class AuthAwareInjectorHolder<T : Injector> :
-    Fragment(),
-    AuthAwareFragment,
-    InjectorHolder<T>
-
-abstract class AuthOptionalInjectorHolder<T : Injector> :
-    Fragment(),
-    AuthOptionalFragment,
-    InjectorHolder<T>
-
-abstract class AuthRequiredInjectorHolder<T : Injector> :
-    Fragment(),
-    AuthRequiredFragment,
-    InjectorHolder<T>
 
 class InjectorViewModelFactory<InjectorType : Injector>(
     private val injectorFactory: InjectorFactory<InjectorType>


### PR DESCRIPTION
Having a `UserProvider` provides us two benefits

1. We have a common way of seeing if we have a user. Just check `if (user == null)`
2. We can use that logic internally to create a smarter injector factory